### PR TITLE
fix bug in tools/vector.c and kern/trap/vector.S

### DIFF
--- a/labcodes/lab1/kern/trap/vectors.S
+++ b/labcodes/lab1/kern/trap/vectors.S
@@ -47,6 +47,7 @@ vector8:
   jmp __alltraps
 .globl vector9
 vector9:
+  pushl $0
   pushl $9
   jmp __alltraps
 .globl vector10

--- a/labcodes/lab1/tools/vector.c
+++ b/labcodes/lab1/tools/vector.c
@@ -2,6 +2,7 @@
 
 int
 main(void) {
+    printf("# handler\n");
     printf(".text\n");
     printf(".globl __alltraps\n");
 
@@ -9,8 +10,8 @@ main(void) {
     for (i = 0; i < 256; i ++) {
         printf(".globl vector%d\n", i);
         printf("vector%d:\n", i);
-        if ((i < 8 || i > 14) && i != 17) {
-            printf("  pushl \\$0\n");
+        if (i != 8 && (i < 10 || i > 14) && i != 17) {
+            printf("  pushl $0\n");
         }
         printf("  pushl $%d\n", i);
         printf("  jmp __alltraps\n");

--- a/labcodes/lab2/kern/trap/vectors.S
+++ b/labcodes/lab2/kern/trap/vectors.S
@@ -47,6 +47,7 @@ vector8:
   jmp __alltraps
 .globl vector9
 vector9:
+  pushl $0
   pushl $9
   jmp __alltraps
 .globl vector10

--- a/labcodes/lab2/tools/vector.c
+++ b/labcodes/lab2/tools/vector.c
@@ -10,7 +10,7 @@ main(void) {
     for (i = 0; i < 256; i ++) {
         printf(".globl vector%d\n", i);
         printf("vector%d:\n", i);
-        if ((i < 8 || i > 14) && i != 17) {
+        if (i != 8 && (i < 10 || i > 14) && i != 17) {
             printf("  pushl $0\n");
         }
         printf("  pushl $%d\n", i);

--- a/labcodes/lab3/kern/trap/vectors.S
+++ b/labcodes/lab3/kern/trap/vectors.S
@@ -47,6 +47,7 @@ vector8:
   jmp __alltraps
 .globl vector9
 vector9:
+  pushl $0
   pushl $9
   jmp __alltraps
 .globl vector10

--- a/labcodes/lab3/tools/vector.c
+++ b/labcodes/lab3/tools/vector.c
@@ -10,7 +10,7 @@ main(void) {
     for (i = 0; i < 256; i ++) {
         printf(".globl vector%d\n", i);
         printf("vector%d:\n", i);
-        if ((i < 8 || i > 14) && i != 17) {
+        if (i != 8 && (i < 10 || i > 14) && i != 17) {
             printf("  pushl $0\n");
         }
         printf("  pushl $%d\n", i);

--- a/labcodes/lab4/kern/trap/vectors.S
+++ b/labcodes/lab4/kern/trap/vectors.S
@@ -47,6 +47,7 @@ vector8:
   jmp __alltraps
 .globl vector9
 vector9:
+  pushl $0
   pushl $9
   jmp __alltraps
 .globl vector10

--- a/labcodes/lab4/tools/vector.c
+++ b/labcodes/lab4/tools/vector.c
@@ -10,7 +10,7 @@ main(void) {
     for (i = 0; i < 256; i ++) {
         printf(".globl vector%d\n", i);
         printf("vector%d:\n", i);
-        if ((i < 8 || i > 14) && i != 17) {
+        if (i != 8 && (i < 10 || i > 14) && i != 17) {
             printf("  pushl $0\n");
         }
         printf("  pushl $%d\n", i);

--- a/labcodes/lab5/kern/trap/vectors.S
+++ b/labcodes/lab5/kern/trap/vectors.S
@@ -47,6 +47,7 @@ vector8:
   jmp __alltraps
 .globl vector9
 vector9:
+  pushl $0
   pushl $9
   jmp __alltraps
 .globl vector10

--- a/labcodes/lab5/tools/vector.c
+++ b/labcodes/lab5/tools/vector.c
@@ -10,7 +10,7 @@ main(void) {
     for (i = 0; i < 256; i ++) {
         printf(".globl vector%d\n", i);
         printf("vector%d:\n", i);
-        if ((i < 8 || i > 14) && i != 17) {
+        if (i != 8 && (i < 10 || i > 14) && i != 17) {
             printf("  pushl $0\n");
         }
         printf("  pushl $%d\n", i);

--- a/labcodes/lab6/kern/trap/vectors.S
+++ b/labcodes/lab6/kern/trap/vectors.S
@@ -47,6 +47,7 @@ vector8:
   jmp __alltraps
 .globl vector9
 vector9:
+  pushl $0
   pushl $9
   jmp __alltraps
 .globl vector10

--- a/labcodes/lab6/tools/vector.c
+++ b/labcodes/lab6/tools/vector.c
@@ -10,7 +10,7 @@ main(void) {
     for (i = 0; i < 256; i ++) {
         printf(".globl vector%d\n", i);
         printf("vector%d:\n", i);
-        if ((i < 8 || i > 14) && i != 17) {
+        if (i != 8 && (i < 10 || i > 14) && i != 17) {
             printf("  pushl $0\n");
         }
         printf("  pushl $%d\n", i);

--- a/labcodes/lab7/kern/trap/vectors.S
+++ b/labcodes/lab7/kern/trap/vectors.S
@@ -47,6 +47,7 @@ vector8:
   jmp __alltraps
 .globl vector9
 vector9:
+  pushl $0
   pushl $9
   jmp __alltraps
 .globl vector10

--- a/labcodes/lab7/tools/vector.c
+++ b/labcodes/lab7/tools/vector.c
@@ -10,7 +10,7 @@ main(void) {
     for (i = 0; i < 256; i ++) {
         printf(".globl vector%d\n", i);
         printf("vector%d:\n", i);
-        if ((i < 8 || i > 14) && i != 17) {
+        if (i != 8 && (i < 10 || i > 14) && i != 17) {
             printf("  pushl $0\n");
         }
         printf("  pushl $%d\n", i);

--- a/labcodes/lab8/kern/trap/vectors.S
+++ b/labcodes/lab8/kern/trap/vectors.S
@@ -47,6 +47,7 @@ vector8:
   jmp __alltraps
 .globl vector9
 vector9:
+  pushl $0
   pushl $9
   jmp __alltraps
 .globl vector10

--- a/labcodes/lab8/tools/vector.c
+++ b/labcodes/lab8/tools/vector.c
@@ -10,7 +10,7 @@ main(void) {
     for (i = 0; i < 256; i ++) {
         printf(".globl vector%d\n", i);
         printf("vector%d:\n", i);
-        if ((i < 8 || i > 14) && i != 17) {
+        if (i != 8 && (i < 10 || i > 14) && i != 17) {
             printf("  pushl $0\n");
         }
         printf("  pushl $%d\n", i);


### PR DESCRIPTION
Interrupt 9 has no exception error code. So the code of `vector9` should push a `0`.
Reference: 6.15 of _Intel® 64 and IA-32 Architectures Software Developer’s Manual_