### PR TITLE
修正Lab2 Makefile中qemu-nox的依赖

### DIFF
--- a/labcodes/lab2/Makefile
+++ b/labcodes/lab2/Makefile
@@ -236,7 +236,7 @@ qemu-mon: $(UCOREIMG)
 qemu: $(UCOREIMG)
 	$(V)$(QEMU)  -no-reboot -parallel stdio $(QEMUOPTS) -serial null
 
-qemu-nox: targets
+qemu-nox: $(UCOREIMG)
 	$(V)$(QEMU)  -no-reboot -serial mon:stdio $(QEMUOPTS) -nographic
 
 TERMINAL := gnome-terminal


### PR DESCRIPTION
原依赖中的`targets`并没有被定义。