### PR TITLE
Try to rewrite the answer of lab2 first-fit

### DIFF
--- a/labcodes_answer/lab2_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab2_result/kern/mm/default_pmm.c
@@ -71,15 +71,13 @@ default_init_memmap(struct Page *base, size_t n) {
     struct Page *p = base;
     for (; p != base + n; p ++) {
         assert(PageReserved(p));
-        p->flags = 0;
-        SetPageProperty(p);
-        p->property = 0;
+        p->flags = p->property = 0;
         set_page_ref(p, 0);
-        list_add_before(&free_list, &(p->page_link));
     }
-    nr_free += n;
-    //first block
     base->property = n;
+    SetPageProperty(base);
+    nr_free += n;
+    list_add(&free_list, &(base->page_link));
 }
 
 static struct Page *
@@ -88,77 +86,69 @@ default_alloc_pages(size_t n) {
     if (n > nr_free) {
         return NULL;
     }
-    list_entry_t *le, *len;
-    le = &free_list;
-
-    while((le=list_next(le)) != &free_list) {
-      struct Page *p = le2page(le, page_link);
-      if(p->property >= n){
-        int i;
-        for(i=0;i<n;i++){
-          len = list_next(le);
-          struct Page *pp = le2page(le, page_link);
-          SetPageReserved(pp);
-          ClearPageProperty(pp);
-          list_del(le);
-          le = len;
+    struct Page *page = NULL;
+    list_entry_t *le = &free_list;
+    // TODO: optimize (next-fit)
+    while ((le = list_next(le)) != &free_list) {
+        struct Page *p = le2page(le, page_link);
+        if (p->property >= n) {
+            page = p;
+            break;
         }
-        if(p->property>n){
-          (le2page(le,page_link))->property = p->property - n;
-        }
-        ClearPageProperty(p);
-        SetPageReserved(p);
-        nr_free -= n;
-        return p;
-      }
     }
-    return NULL;
+    if (page != NULL) {
+        if (page->property > n) {
+            struct Page *p = page + n;
+            p->property = page->property - n;
+            SetPageProperty(p);
+            list_add_after(&(page->page_link), &(p->page_link));
+        }
+        list_del(&(page->page_link));
+        nr_free -= n;
+        ClearPageProperty(page);
+    }
+    return page;
 }
 
 static void
 default_free_pages(struct Page *base, size_t n) {
     assert(n > 0);
-    assert(PageReserved(base));
-
-    list_entry_t *le = &free_list;
-    struct Page * p;
-    while((le=list_next(le)) != &free_list) {
-      p = le2page(le, page_link);
-      if(p>base){
-        break;
-      }
+    struct Page *p = base;
+    for (; p != base + n; p ++) {
+        assert(!PageReserved(p) && !PageProperty(p));
+        p->flags = 0;
+        set_page_ref(p, 0);
     }
-    //list_add_before(le, base->page_link);
-    for(p=base;p<base+n;p++){
-      list_add_before(le, &(p->page_link));
-    }
-    base->flags = 0;
-    set_page_ref(base, 0);
-    ClearPageProperty(base);
-    SetPageProperty(base);
     base->property = n;
-    
-    p = le2page(le,page_link) ;
-    if( base+n == p ){
-      base->property += p->property;
-      p->property = 0;
-    }
-    le = list_prev(&(base->page_link));
-    p = le2page(le, page_link);
-    if(le!=&free_list && p==base-1){
-      while(le!=&free_list){
-        if(p->property){
-          p->property += base->property;
-          base->property = 0;
-          break;
+    SetPageProperty(base);
+    list_entry_t *le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        le = list_next(le);
+        // TODO: optimize
+        if (base + base->property == p) {
+            base->property += p->property;
+            ClearPageProperty(p);
+            list_del(&(p->page_link));
         }
-        le = list_prev(le);
-        p = le2page(le,page_link);
-      }
+        else if (p + p->property == base) {
+            p->property += base->property;
+            ClearPageProperty(base);
+            base = p;
+            list_del(&(p->page_link));
+        }
     }
-
     nr_free += n;
-    return ;
+    le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        if (base + base->property <= p) {
+            assert(base + base->property != p);
+            break;
+        }
+        le = list_next(le);
+    }
+    list_add_before(le, &(base->page_link));
 }
 
 static size_t
@@ -291,4 +281,3 @@ const struct pmm_manager default_pmm_manager = {
     .nr_free_pages = default_nr_free_pages,
     .check = default_check,
 };
-

--- a/labcodes_answer/lab2_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab2_result/kern/mm/default_pmm.c
@@ -77,7 +77,7 @@ default_init_memmap(struct Page *base, size_t n) {
     base->property = n;
     SetPageProperty(base);
     nr_free += n;
-    list_add(&free_list, &(base->page_link));
+    list_add_before(&free_list, &(base->page_link));
 }
 
 static struct Page *

--- a/labcodes_answer/lab3_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab3_result/kern/mm/default_pmm.c
@@ -71,15 +71,13 @@ default_init_memmap(struct Page *base, size_t n) {
     struct Page *p = base;
     for (; p != base + n; p ++) {
         assert(PageReserved(p));
-        p->flags = 0;
-        SetPageProperty(p);
-        p->property = 0;
+        p->flags = p->property = 0;
         set_page_ref(p, 0);
-        list_add_before(&free_list, &(p->page_link));
     }
-    nr_free += n;
-    //first block
     base->property = n;
+    SetPageProperty(base);
+    nr_free += n;
+    list_add(&free_list, &(base->page_link));
 }
 
 static struct Page *
@@ -88,77 +86,69 @@ default_alloc_pages(size_t n) {
     if (n > nr_free) {
         return NULL;
     }
-    list_entry_t *le, *len;
-    le = &free_list;
-
-    while((le=list_next(le)) != &free_list) {
-      struct Page *p = le2page(le, page_link);
-      if(p->property >= n){
-        int i;
-        for(i=0;i<n;i++){
-          len = list_next(le);
-          struct Page *pp = le2page(le, page_link);
-          SetPageReserved(pp);
-          ClearPageProperty(pp);
-          list_del(le);
-          le = len;
+    struct Page *page = NULL;
+    list_entry_t *le = &free_list;
+    // TODO: optimize (next-fit)
+    while ((le = list_next(le)) != &free_list) {
+        struct Page *p = le2page(le, page_link);
+        if (p->property >= n) {
+            page = p;
+            break;
         }
-        if(p->property>n){
-          (le2page(le,page_link))->property = p->property - n;
-        }
-        ClearPageProperty(p);
-        SetPageReserved(p);
-        nr_free -= n;
-        return p;
-      }
     }
-    return NULL;
+    if (page != NULL) {
+        if (page->property > n) {
+            struct Page *p = page + n;
+            p->property = page->property - n;
+            SetPageProperty(p);
+            list_add_after(&(page->page_link), &(p->page_link));
+        }
+        list_del(&(page->page_link));
+        nr_free -= n;
+        ClearPageProperty(page);
+    }
+    return page;
 }
 
 static void
 default_free_pages(struct Page *base, size_t n) {
     assert(n > 0);
-    assert(PageReserved(base));
-
-    list_entry_t *le = &free_list;
-    struct Page * p;
-    while((le=list_next(le)) != &free_list) {
-      p = le2page(le, page_link);
-      if(p>base){
-        break;
-      }
+    struct Page *p = base;
+    for (; p != base + n; p ++) {
+        assert(!PageReserved(p) && !PageProperty(p));
+        p->flags = 0;
+        set_page_ref(p, 0);
     }
-    //list_add_before(le, base->page_link);
-    for(p=base;p<base+n;p++){
-      list_add_before(le, &(p->page_link));
-    }
-    base->flags = 0;
-    set_page_ref(base, 0);
-    ClearPageProperty(base);
-    SetPageProperty(base);
     base->property = n;
-    
-    p = le2page(le,page_link) ;
-    if( base+n == p ){
-      base->property += p->property;
-      p->property = 0;
-    }
-    le = list_prev(&(base->page_link));
-    p = le2page(le, page_link);
-    if(le!=&free_list && p==base-1){
-      while(le!=&free_list){
-        if(p->property){
-          p->property += base->property;
-          base->property = 0;
-          break;
+    SetPageProperty(base);
+    list_entry_t *le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        le = list_next(le);
+        // TODO: optimize
+        if (base + base->property == p) {
+            base->property += p->property;
+            ClearPageProperty(p);
+            list_del(&(p->page_link));
         }
-        le = list_prev(le);
-        p = le2page(le,page_link);
-      }
+        else if (p + p->property == base) {
+            p->property += base->property;
+            ClearPageProperty(base);
+            base = p;
+            list_del(&(p->page_link));
+        }
     }
-
     nr_free += n;
-    return ;
+    le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        if (base + base->property <= p) {
+            assert(base + base->property != p);
+            break;
+        }
+        le = list_next(le);
+    }
+    list_add_before(le, &(base->page_link));
 }
 
 static size_t
@@ -291,4 +281,3 @@ const struct pmm_manager default_pmm_manager = {
     .nr_free_pages = default_nr_free_pages,
     .check = default_check,
 };
-

--- a/labcodes_answer/lab3_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab3_result/kern/mm/default_pmm.c
@@ -77,7 +77,7 @@ default_init_memmap(struct Page *base, size_t n) {
     base->property = n;
     SetPageProperty(base);
     nr_free += n;
-    list_add(&free_list, &(base->page_link));
+    list_add_before(&free_list, &(base->page_link));
 }
 
 static struct Page *

--- a/labcodes_answer/lab4_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab4_result/kern/mm/default_pmm.c
@@ -71,15 +71,13 @@ default_init_memmap(struct Page *base, size_t n) {
     struct Page *p = base;
     for (; p != base + n; p ++) {
         assert(PageReserved(p));
-        p->flags = 0;
-        SetPageProperty(p);
-        p->property = 0;
+        p->flags = p->property = 0;
         set_page_ref(p, 0);
-        list_add_before(&free_list, &(p->page_link));
     }
-    nr_free += n;
-    //first block
     base->property = n;
+    SetPageProperty(base);
+    nr_free += n;
+    list_add(&free_list, &(base->page_link));
 }
 
 static struct Page *
@@ -88,77 +86,69 @@ default_alloc_pages(size_t n) {
     if (n > nr_free) {
         return NULL;
     }
-    list_entry_t *le, *len;
-    le = &free_list;
-
-    while((le=list_next(le)) != &free_list) {
-      struct Page *p = le2page(le, page_link);
-      if(p->property >= n){
-        int i;
-        for(i=0;i<n;i++){
-          len = list_next(le);
-          struct Page *pp = le2page(le, page_link);
-          SetPageReserved(pp);
-          ClearPageProperty(pp);
-          list_del(le);
-          le = len;
+    struct Page *page = NULL;
+    list_entry_t *le = &free_list;
+    // TODO: optimize (next-fit)
+    while ((le = list_next(le)) != &free_list) {
+        struct Page *p = le2page(le, page_link);
+        if (p->property >= n) {
+            page = p;
+            break;
         }
-        if(p->property>n){
-          (le2page(le,page_link))->property = p->property - n;
-        }
-        ClearPageProperty(p);
-        SetPageReserved(p);
-        nr_free -= n;
-        return p;
-      }
     }
-    return NULL;
+    if (page != NULL) {
+        if (page->property > n) {
+            struct Page *p = page + n;
+            p->property = page->property - n;
+            SetPageProperty(p);
+            list_add_after(&(page->page_link), &(p->page_link));
+        }
+        list_del(&(page->page_link));
+        nr_free -= n;
+        ClearPageProperty(page);
+    }
+    return page;
 }
 
 static void
 default_free_pages(struct Page *base, size_t n) {
     assert(n > 0);
-    assert(PageReserved(base));
-
-    list_entry_t *le = &free_list;
-    struct Page * p;
-    while((le=list_next(le)) != &free_list) {
-      p = le2page(le, page_link);
-      if(p>base){
-        break;
-      }
+    struct Page *p = base;
+    for (; p != base + n; p ++) {
+        assert(!PageReserved(p) && !PageProperty(p));
+        p->flags = 0;
+        set_page_ref(p, 0);
     }
-    //list_add_before(le, base->page_link);
-    for(p=base;p<base+n;p++){
-      list_add_before(le, &(p->page_link));
-    }
-    base->flags = 0;
-    set_page_ref(base, 0);
-    ClearPageProperty(base);
-    SetPageProperty(base);
     base->property = n;
-    
-    p = le2page(le,page_link) ;
-    if( base+n == p ){
-      base->property += p->property;
-      p->property = 0;
-    }
-    le = list_prev(&(base->page_link));
-    p = le2page(le, page_link);
-    if(le!=&free_list && p==base-1){
-      while(le!=&free_list){
-        if(p->property){
-          p->property += base->property;
-          base->property = 0;
-          break;
+    SetPageProperty(base);
+    list_entry_t *le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        le = list_next(le);
+        // TODO: optimize
+        if (base + base->property == p) {
+            base->property += p->property;
+            ClearPageProperty(p);
+            list_del(&(p->page_link));
         }
-        le = list_prev(le);
-        p = le2page(le,page_link);
-      }
+        else if (p + p->property == base) {
+            p->property += base->property;
+            ClearPageProperty(base);
+            base = p;
+            list_del(&(p->page_link));
+        }
     }
-
     nr_free += n;
-    return ;
+    le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        if (base + base->property <= p) {
+            assert(base + base->property != p);
+            break;
+        }
+        le = list_next(le);
+    }
+    list_add_before(le, &(base->page_link));
 }
 
 static size_t
@@ -291,4 +281,3 @@ const struct pmm_manager default_pmm_manager = {
     .nr_free_pages = default_nr_free_pages,
     .check = default_check,
 };
-

--- a/labcodes_answer/lab4_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab4_result/kern/mm/default_pmm.c
@@ -77,7 +77,7 @@ default_init_memmap(struct Page *base, size_t n) {
     base->property = n;
     SetPageProperty(base);
     nr_free += n;
-    list_add(&free_list, &(base->page_link));
+    list_add_before(&free_list, &(base->page_link));
 }
 
 static struct Page *

--- a/labcodes_answer/lab5_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab5_result/kern/mm/default_pmm.c
@@ -71,15 +71,13 @@ default_init_memmap(struct Page *base, size_t n) {
     struct Page *p = base;
     for (; p != base + n; p ++) {
         assert(PageReserved(p));
-        p->flags = 0;
-        SetPageProperty(p);
-        p->property = 0;
+        p->flags = p->property = 0;
         set_page_ref(p, 0);
-        list_add_before(&free_list, &(p->page_link));
     }
-    nr_free += n;
-    //first block
     base->property = n;
+    SetPageProperty(base);
+    nr_free += n;
+    list_add(&free_list, &(base->page_link));
 }
 
 static struct Page *
@@ -88,77 +86,69 @@ default_alloc_pages(size_t n) {
     if (n > nr_free) {
         return NULL;
     }
-    list_entry_t *le, *len;
-    le = &free_list;
-
-    while((le=list_next(le)) != &free_list) {
-      struct Page *p = le2page(le, page_link);
-      if(p->property >= n){
-        int i;
-        for(i=0;i<n;i++){
-          len = list_next(le);
-          struct Page *pp = le2page(le, page_link);
-          SetPageReserved(pp);
-          ClearPageProperty(pp);
-          list_del(le);
-          le = len;
+    struct Page *page = NULL;
+    list_entry_t *le = &free_list;
+    // TODO: optimize (next-fit)
+    while ((le = list_next(le)) != &free_list) {
+        struct Page *p = le2page(le, page_link);
+        if (p->property >= n) {
+            page = p;
+            break;
         }
-        if(p->property>n){
-          (le2page(le,page_link))->property = p->property - n;
-        }
-        ClearPageProperty(p);
-        SetPageReserved(p);
-        nr_free -= n;
-        return p;
-      }
     }
-    return NULL;
+    if (page != NULL) {
+        if (page->property > n) {
+            struct Page *p = page + n;
+            p->property = page->property - n;
+            SetPageProperty(p);
+            list_add_after(&(page->page_link), &(p->page_link));
+        }
+        list_del(&(page->page_link));
+        nr_free -= n;
+        ClearPageProperty(page);
+    }
+    return page;
 }
 
 static void
 default_free_pages(struct Page *base, size_t n) {
     assert(n > 0);
-    assert(PageReserved(base));
-
-    list_entry_t *le = &free_list;
-    struct Page * p;
-    while((le=list_next(le)) != &free_list) {
-      p = le2page(le, page_link);
-      if(p>base){
-        break;
-      }
+    struct Page *p = base;
+    for (; p != base + n; p ++) {
+        assert(!PageReserved(p) && !PageProperty(p));
+        p->flags = 0;
+        set_page_ref(p, 0);
     }
-    //list_add_before(le, base->page_link);
-    for(p=base;p<base+n;p++){
-      list_add_before(le, &(p->page_link));
-    }
-    base->flags = 0;
-    set_page_ref(base, 0);
-    ClearPageProperty(base);
-    SetPageProperty(base);
     base->property = n;
-    
-    p = le2page(le,page_link) ;
-    if( base+n == p ){
-      base->property += p->property;
-      p->property = 0;
-    }
-    le = list_prev(&(base->page_link));
-    p = le2page(le, page_link);
-    if(le!=&free_list && p==base-1){
-      while(le!=&free_list){
-        if(p->property){
-          p->property += base->property;
-          base->property = 0;
-          break;
+    SetPageProperty(base);
+    list_entry_t *le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        le = list_next(le);
+        // TODO: optimize
+        if (base + base->property == p) {
+            base->property += p->property;
+            ClearPageProperty(p);
+            list_del(&(p->page_link));
         }
-        le = list_prev(le);
-        p = le2page(le,page_link);
-      }
+        else if (p + p->property == base) {
+            p->property += base->property;
+            ClearPageProperty(base);
+            base = p;
+            list_del(&(p->page_link));
+        }
     }
-
     nr_free += n;
-    return ;
+    le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        if (base + base->property <= p) {
+            assert(base + base->property != p);
+            break;
+        }
+        le = list_next(le);
+    }
+    list_add_before(le, &(base->page_link));
 }
 
 static size_t
@@ -291,4 +281,3 @@ const struct pmm_manager default_pmm_manager = {
     .nr_free_pages = default_nr_free_pages,
     .check = default_check,
 };
-

--- a/labcodes_answer/lab5_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab5_result/kern/mm/default_pmm.c
@@ -77,7 +77,7 @@ default_init_memmap(struct Page *base, size_t n) {
     base->property = n;
     SetPageProperty(base);
     nr_free += n;
-    list_add(&free_list, &(base->page_link));
+    list_add_before(&free_list, &(base->page_link));
 }
 
 static struct Page *

--- a/labcodes_answer/lab6_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab6_result/kern/mm/default_pmm.c
@@ -71,15 +71,13 @@ default_init_memmap(struct Page *base, size_t n) {
     struct Page *p = base;
     for (; p != base + n; p ++) {
         assert(PageReserved(p));
-        p->flags = 0;
-        SetPageProperty(p);
-        p->property = 0;
+        p->flags = p->property = 0;
         set_page_ref(p, 0);
-        list_add_before(&free_list, &(p->page_link));
     }
-    nr_free += n;
-    //first block
     base->property = n;
+    SetPageProperty(base);
+    nr_free += n;
+    list_add(&free_list, &(base->page_link));
 }
 
 static struct Page *
@@ -88,77 +86,69 @@ default_alloc_pages(size_t n) {
     if (n > nr_free) {
         return NULL;
     }
-    list_entry_t *le, *len;
-    le = &free_list;
-
-    while((le=list_next(le)) != &free_list) {
-      struct Page *p = le2page(le, page_link);
-      if(p->property >= n){
-        int i;
-        for(i=0;i<n;i++){
-          len = list_next(le);
-          struct Page *pp = le2page(le, page_link);
-          SetPageReserved(pp);
-          ClearPageProperty(pp);
-          list_del(le);
-          le = len;
+    struct Page *page = NULL;
+    list_entry_t *le = &free_list;
+    // TODO: optimize (next-fit)
+    while ((le = list_next(le)) != &free_list) {
+        struct Page *p = le2page(le, page_link);
+        if (p->property >= n) {
+            page = p;
+            break;
         }
-        if(p->property>n){
-          (le2page(le,page_link))->property = p->property - n;
-        }
-        ClearPageProperty(p);
-        SetPageReserved(p);
-        nr_free -= n;
-        return p;
-      }
     }
-    return NULL;
+    if (page != NULL) {
+        if (page->property > n) {
+            struct Page *p = page + n;
+            p->property = page->property - n;
+            SetPageProperty(p);
+            list_add_after(&(page->page_link), &(p->page_link));
+        }
+        list_del(&(page->page_link));
+        nr_free -= n;
+        ClearPageProperty(page);
+    }
+    return page;
 }
 
 static void
 default_free_pages(struct Page *base, size_t n) {
     assert(n > 0);
-    assert(PageReserved(base));
-
-    list_entry_t *le = &free_list;
-    struct Page * p;
-    while((le=list_next(le)) != &free_list) {
-      p = le2page(le, page_link);
-      if(p>base){
-        break;
-      }
+    struct Page *p = base;
+    for (; p != base + n; p ++) {
+        assert(!PageReserved(p) && !PageProperty(p));
+        p->flags = 0;
+        set_page_ref(p, 0);
     }
-    //list_add_before(le, base->page_link);
-    for(p=base;p<base+n;p++){
-      list_add_before(le, &(p->page_link));
-    }
-    base->flags = 0;
-    set_page_ref(base, 0);
-    ClearPageProperty(base);
-    SetPageProperty(base);
     base->property = n;
-    
-    p = le2page(le,page_link) ;
-    if( base+n == p ){
-      base->property += p->property;
-      p->property = 0;
-    }
-    le = list_prev(&(base->page_link));
-    p = le2page(le, page_link);
-    if(le!=&free_list && p==base-1){
-      while(le!=&free_list){
-        if(p->property){
-          p->property += base->property;
-          base->property = 0;
-          break;
+    SetPageProperty(base);
+    list_entry_t *le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        le = list_next(le);
+        // TODO: optimize
+        if (base + base->property == p) {
+            base->property += p->property;
+            ClearPageProperty(p);
+            list_del(&(p->page_link));
         }
-        le = list_prev(le);
-        p = le2page(le,page_link);
-      }
+        else if (p + p->property == base) {
+            p->property += base->property;
+            ClearPageProperty(base);
+            base = p;
+            list_del(&(p->page_link));
+        }
     }
-
     nr_free += n;
-    return ;
+    le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        if (base + base->property <= p) {
+            assert(base + base->property != p);
+            break;
+        }
+        le = list_next(le);
+    }
+    list_add_before(le, &(base->page_link));
 }
 
 static size_t
@@ -291,4 +281,3 @@ const struct pmm_manager default_pmm_manager = {
     .nr_free_pages = default_nr_free_pages,
     .check = default_check,
 };
-

--- a/labcodes_answer/lab6_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab6_result/kern/mm/default_pmm.c
@@ -77,7 +77,7 @@ default_init_memmap(struct Page *base, size_t n) {
     base->property = n;
     SetPageProperty(base);
     nr_free += n;
-    list_add(&free_list, &(base->page_link));
+    list_add_before(&free_list, &(base->page_link));
 }
 
 static struct Page *

--- a/labcodes_answer/lab7_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab7_result/kern/mm/default_pmm.c
@@ -71,15 +71,13 @@ default_init_memmap(struct Page *base, size_t n) {
     struct Page *p = base;
     for (; p != base + n; p ++) {
         assert(PageReserved(p));
-        p->flags = 0;
-        SetPageProperty(p);
-        p->property = 0;
+        p->flags = p->property = 0;
         set_page_ref(p, 0);
-        list_add_before(&free_list, &(p->page_link));
     }
-    nr_free += n;
-    //first block
     base->property = n;
+    SetPageProperty(base);
+    nr_free += n;
+    list_add(&free_list, &(base->page_link));
 }
 
 static struct Page *
@@ -88,77 +86,69 @@ default_alloc_pages(size_t n) {
     if (n > nr_free) {
         return NULL;
     }
-    list_entry_t *le, *len;
-    le = &free_list;
-
-    while((le=list_next(le)) != &free_list) {
-      struct Page *p = le2page(le, page_link);
-      if(p->property >= n){
-        int i;
-        for(i=0;i<n;i++){
-          len = list_next(le);
-          struct Page *pp = le2page(le, page_link);
-          SetPageReserved(pp);
-          ClearPageProperty(pp);
-          list_del(le);
-          le = len;
+    struct Page *page = NULL;
+    list_entry_t *le = &free_list;
+    // TODO: optimize (next-fit)
+    while ((le = list_next(le)) != &free_list) {
+        struct Page *p = le2page(le, page_link);
+        if (p->property >= n) {
+            page = p;
+            break;
         }
-        if(p->property>n){
-          (le2page(le,page_link))->property = p->property - n;
-        }
-        ClearPageProperty(p);
-        SetPageReserved(p);
-        nr_free -= n;
-        return p;
-      }
     }
-    return NULL;
+    if (page != NULL) {
+        if (page->property > n) {
+            struct Page *p = page + n;
+            p->property = page->property - n;
+            SetPageProperty(p);
+            list_add_after(&(page->page_link), &(p->page_link));
+        }
+        list_del(&(page->page_link));
+        nr_free -= n;
+        ClearPageProperty(page);
+    }
+    return page;
 }
 
 static void
 default_free_pages(struct Page *base, size_t n) {
     assert(n > 0);
-    assert(PageReserved(base));
-
-    list_entry_t *le = &free_list;
-    struct Page * p;
-    while((le=list_next(le)) != &free_list) {
-      p = le2page(le, page_link);
-      if(p>base){
-        break;
-      }
+    struct Page *p = base;
+    for (; p != base + n; p ++) {
+        assert(!PageReserved(p) && !PageProperty(p));
+        p->flags = 0;
+        set_page_ref(p, 0);
     }
-    //list_add_before(le, base->page_link);
-    for(p=base;p<base+n;p++){
-      list_add_before(le, &(p->page_link));
-    }
-    base->flags = 0;
-    set_page_ref(base, 0);
-    ClearPageProperty(base);
-    SetPageProperty(base);
     base->property = n;
-    
-    p = le2page(le,page_link) ;
-    if( base+n == p ){
-      base->property += p->property;
-      p->property = 0;
-    }
-    le = list_prev(&(base->page_link));
-    p = le2page(le, page_link);
-    if(le!=&free_list && p==base-1){
-      while(le!=&free_list){
-        if(p->property){
-          p->property += base->property;
-          base->property = 0;
-          break;
+    SetPageProperty(base);
+    list_entry_t *le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        le = list_next(le);
+        // TODO: optimize
+        if (base + base->property == p) {
+            base->property += p->property;
+            ClearPageProperty(p);
+            list_del(&(p->page_link));
         }
-        le = list_prev(le);
-        p = le2page(le,page_link);
-      }
+        else if (p + p->property == base) {
+            p->property += base->property;
+            ClearPageProperty(base);
+            base = p;
+            list_del(&(p->page_link));
+        }
     }
-
     nr_free += n;
-    return ;
+    le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        if (base + base->property <= p) {
+            assert(base + base->property != p);
+            break;
+        }
+        le = list_next(le);
+    }
+    list_add_before(le, &(base->page_link));
 }
 
 static size_t
@@ -291,4 +281,3 @@ const struct pmm_manager default_pmm_manager = {
     .nr_free_pages = default_nr_free_pages,
     .check = default_check,
 };
-

--- a/labcodes_answer/lab7_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab7_result/kern/mm/default_pmm.c
@@ -77,7 +77,7 @@ default_init_memmap(struct Page *base, size_t n) {
     base->property = n;
     SetPageProperty(base);
     nr_free += n;
-    list_add(&free_list, &(base->page_link));
+    list_add_before(&free_list, &(base->page_link));
 }
 
 static struct Page *

--- a/labcodes_answer/lab8_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab8_result/kern/mm/default_pmm.c
@@ -71,15 +71,13 @@ default_init_memmap(struct Page *base, size_t n) {
     struct Page *p = base;
     for (; p != base + n; p ++) {
         assert(PageReserved(p));
-        p->flags = 0;
-        SetPageProperty(p);
-        p->property = 0;
+        p->flags = p->property = 0;
         set_page_ref(p, 0);
-        list_add_before(&free_list, &(p->page_link));
     }
-    nr_free += n;
-    //first block
     base->property = n;
+    SetPageProperty(base);
+    nr_free += n;
+    list_add(&free_list, &(base->page_link));
 }
 
 static struct Page *
@@ -88,77 +86,69 @@ default_alloc_pages(size_t n) {
     if (n > nr_free) {
         return NULL;
     }
-    list_entry_t *le, *len;
-    le = &free_list;
-
-    while((le=list_next(le)) != &free_list) {
-      struct Page *p = le2page(le, page_link);
-      if(p->property >= n){
-        int i;
-        for(i=0;i<n;i++){
-          len = list_next(le);
-          struct Page *pp = le2page(le, page_link);
-          SetPageReserved(pp);
-          ClearPageProperty(pp);
-          list_del(le);
-          le = len;
+    struct Page *page = NULL;
+    list_entry_t *le = &free_list;
+    // TODO: optimize (next-fit)
+    while ((le = list_next(le)) != &free_list) {
+        struct Page *p = le2page(le, page_link);
+        if (p->property >= n) {
+            page = p;
+            break;
         }
-        if(p->property>n){
-          (le2page(le,page_link))->property = p->property - n;
-        }
-        ClearPageProperty(p);
-        SetPageReserved(p);
-        nr_free -= n;
-        return p;
-      }
     }
-    return NULL;
+    if (page != NULL) {
+        if (page->property > n) {
+            struct Page *p = page + n;
+            p->property = page->property - n;
+            SetPageProperty(p);
+            list_add_after(&(page->page_link), &(p->page_link));
+        }
+        list_del(&(page->page_link));
+        nr_free -= n;
+        ClearPageProperty(page);
+    }
+    return page;
 }
 
 static void
 default_free_pages(struct Page *base, size_t n) {
     assert(n > 0);
-    assert(PageReserved(base));
-
-    list_entry_t *le = &free_list;
-    struct Page * p;
-    while((le=list_next(le)) != &free_list) {
-      p = le2page(le, page_link);
-      if(p>base){
-        break;
-      }
+    struct Page *p = base;
+    for (; p != base + n; p ++) {
+        assert(!PageReserved(p) && !PageProperty(p));
+        p->flags = 0;
+        set_page_ref(p, 0);
     }
-    //list_add_before(le, base->page_link);
-    for(p=base;p<base+n;p++){
-      list_add_before(le, &(p->page_link));
-    }
-    base->flags = 0;
-    set_page_ref(base, 0);
-    ClearPageProperty(base);
-    SetPageProperty(base);
     base->property = n;
-    
-    p = le2page(le,page_link) ;
-    if( base+n == p ){
-      base->property += p->property;
-      p->property = 0;
-    }
-    le = list_prev(&(base->page_link));
-    p = le2page(le, page_link);
-    if(le!=&free_list && p==base-1){
-      while(le!=&free_list){
-        if(p->property){
-          p->property += base->property;
-          base->property = 0;
-          break;
+    SetPageProperty(base);
+    list_entry_t *le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        le = list_next(le);
+        // TODO: optimize
+        if (base + base->property == p) {
+            base->property += p->property;
+            ClearPageProperty(p);
+            list_del(&(p->page_link));
         }
-        le = list_prev(le);
-        p = le2page(le,page_link);
-      }
+        else if (p + p->property == base) {
+            p->property += base->property;
+            ClearPageProperty(base);
+            base = p;
+            list_del(&(p->page_link));
+        }
     }
-
     nr_free += n;
-    return ;
+    le = list_next(&free_list);
+    while (le != &free_list) {
+        p = le2page(le, page_link);
+        if (base + base->property <= p) {
+            assert(base + base->property != p);
+            break;
+        }
+        le = list_next(le);
+    }
+    list_add_before(le, &(base->page_link));
 }
 
 static size_t
@@ -291,4 +281,3 @@ const struct pmm_manager default_pmm_manager = {
     .nr_free_pages = default_nr_free_pages,
     .check = default_check,
 };
-

--- a/labcodes_answer/lab8_result/kern/mm/default_pmm.c
+++ b/labcodes_answer/lab8_result/kern/mm/default_pmm.c
@@ -77,7 +77,7 @@ default_init_memmap(struct Page *base, size_t n) {
     base->property = n;
     SetPageProperty(base);
     nr_free += n;
-    list_add(&free_list, &(base->page_link));
+    list_add_before(&free_list, &(base->page_link));
 }
 
 static struct Page *


### PR DESCRIPTION
Try to rewrite the answer of lab2 first-fit and make it fewer differences between `/labcodes/lab2/kern/mm/default_pmm.c`

FYI, `diff labcodes/lab2/kern/mm/default_pmm.c labcodes_answer/lab2_result/kern/mm/default_pmm.c `:

```diff
119c80
<     list_add(&free_list, &(base->page_link));
---
>     list_add_before(&free_list, &(base->page_link));
129a91
>     // TODO: optimize (next-fit)
138d99
<         list_del(&(page->page_link));
142,143c103,106
<             list_add(&free_list, &(p->page_link));
<     }
---
>             SetPageProperty(p);
>             list_add_after(&(page->page_link), &(p->page_link));
>         }
>         list_del(&(page->page_link));
164a128
>         // TODO: optimize
178c142,151
<     list_add(&free_list, &(base->page_link));
---
>     le = list_next(&free_list);
>     while (le != &free_list) {
>         p = le2page(le, page_link);
>         if (base + base->property <= p) {
>             assert(base + base->property != p);
>             break;
>         }
>         le = list_next(le);
>     }
>     list_add_before(le, &(base->page_link));
311d283
< 
```