### PR TITLE
 Kill bothering GDT whose segment base=-KERNBASE.

### DIFF
--- a/labcodes/lab2/kern/init/entry.S
+++ b/labcodes/lab2/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,24 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
+
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr
 

--- a/labcodes/lab2/kern/mm/pmm.c
+++ b/labcodes/lab2/kern/mm/pmm.c
@@ -37,7 +37,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -238,17 +239,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -284,6 +274,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -298,11 +291,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -312,23 +300,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes/lab2/tools/kernel.ld
+++ b/labcodes/lab2/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {

--- a/labcodes/lab3/kern/init/entry.S
+++ b/labcodes/lab3/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,24 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
+
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr
 

--- a/labcodes/lab3/kern/mm/pmm.c
+++ b/labcodes/lab3/kern/mm/pmm.c
@@ -39,7 +39,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -251,17 +252,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -297,6 +287,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -311,11 +304,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -325,23 +313,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes/lab3/tools/kernel.ld
+++ b/labcodes/lab3/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {

--- a/labcodes/lab4/kern/init/entry.S
+++ b/labcodes/lab4/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,24 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
+
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr
 

--- a/labcodes/lab4/kern/mm/pmm.c
+++ b/labcodes/lab4/kern/mm/pmm.c
@@ -40,7 +40,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -252,17 +253,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -298,6 +288,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -312,11 +305,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -326,23 +314,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes/lab4/tools/kernel.ld
+++ b/labcodes/lab4/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {

--- a/labcodes/lab5/kern/init/entry.S
+++ b/labcodes/lab5/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,24 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
+
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr
 

--- a/labcodes/lab5/kern/mm/pmm.c
+++ b/labcodes/lab5/kern/mm/pmm.c
@@ -40,7 +40,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -252,17 +253,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -298,6 +288,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -312,11 +305,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -326,23 +314,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes/lab5/tools/kernel.ld
+++ b/labcodes/lab5/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {

--- a/labcodes/lab6/kern/init/entry.S
+++ b/labcodes/lab6/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,24 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
+
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr
 

--- a/labcodes/lab6/kern/mm/pmm.c
+++ b/labcodes/lab6/kern/mm/pmm.c
@@ -40,7 +40,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -252,17 +253,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -298,6 +288,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -312,11 +305,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -326,23 +314,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes/lab6/tools/kernel.ld
+++ b/labcodes/lab6/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {

--- a/labcodes/lab7/kern/init/entry.S
+++ b/labcodes/lab7/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,24 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
+
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr
 

--- a/labcodes/lab7/kern/mm/pmm.c
+++ b/labcodes/lab7/kern/mm/pmm.c
@@ -40,7 +40,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -252,17 +253,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -298,6 +288,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -312,11 +305,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -326,23 +314,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes/lab7/tools/kernel.ld
+++ b/labcodes/lab7/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {

--- a/labcodes/lab8/kern/init/entry.S
+++ b/labcodes/lab8/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,24 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
+
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr
 

--- a/labcodes/lab8/kern/mm/pmm.c
+++ b/labcodes/lab8/kern/mm/pmm.c
@@ -40,7 +40,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -252,17 +253,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -298,6 +288,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -312,11 +305,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -326,23 +314,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes/lab8/tools/kernel.ld
+++ b/labcodes/lab8/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {

--- a/labcodes_answer/lab2_result/kern/init/entry.S
+++ b/labcodes_answer/lab2_result/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,23 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
 
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr

--- a/labcodes_answer/lab2_result/kern/mm/pmm.c
+++ b/labcodes_answer/lab2_result/kern/mm/pmm.c
@@ -37,7 +37,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -238,17 +239,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -284,6 +274,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -298,11 +291,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -312,23 +300,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes_answer/lab2_result/tools/kernel.ld
+++ b/labcodes_answer/lab2_result/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {

--- a/labcodes_answer/lab3_result/kern/init/entry.S
+++ b/labcodes_answer/lab3_result/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,24 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
+
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr
 

--- a/labcodes_answer/lab3_result/kern/mm/pmm.c
+++ b/labcodes_answer/lab3_result/kern/mm/pmm.c
@@ -39,7 +39,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -251,17 +252,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -297,6 +287,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -311,11 +304,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -325,23 +313,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes_answer/lab3_result/tools/kernel.ld
+++ b/labcodes_answer/lab3_result/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {

--- a/labcodes_answer/lab4_result/kern/init/entry.S
+++ b/labcodes_answer/lab4_result/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,24 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
+
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr
 

--- a/labcodes_answer/lab4_result/kern/mm/pmm.c
+++ b/labcodes_answer/lab4_result/kern/mm/pmm.c
@@ -40,7 +40,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -252,17 +253,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -298,6 +288,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -312,11 +305,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -326,23 +314,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes_answer/lab4_result/tools/kernel.ld
+++ b/labcodes_answer/lab4_result/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {

--- a/labcodes_answer/lab5_result/kern/init/entry.S
+++ b/labcodes_answer/lab5_result/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,24 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
+
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr
 

--- a/labcodes_answer/lab5_result/kern/mm/pmm.c
+++ b/labcodes_answer/lab5_result/kern/mm/pmm.c
@@ -40,7 +40,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -252,17 +253,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -298,6 +288,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -312,11 +305,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -326,23 +314,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes_answer/lab5_result/tools/kernel.ld
+++ b/labcodes_answer/lab5_result/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {

--- a/labcodes_answer/lab6_result/kern/init/entry.S
+++ b/labcodes_answer/lab6_result/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,24 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
+
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr
 

--- a/labcodes_answer/lab6_result/kern/mm/pmm.c
+++ b/labcodes_answer/lab6_result/kern/mm/pmm.c
@@ -40,7 +40,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -252,17 +253,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -298,6 +288,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -312,11 +305,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -326,23 +314,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes_answer/lab6_result/tools/kernel.ld
+++ b/labcodes_answer/lab6_result/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {

--- a/labcodes_answer/lab7_result/kern/init/entry.S
+++ b/labcodes_answer/lab7_result/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,24 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
+
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr
 

--- a/labcodes_answer/lab7_result/kern/mm/pmm.c
+++ b/labcodes_answer/lab7_result/kern/mm/pmm.c
@@ -40,7 +40,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -252,17 +253,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -298,6 +288,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -312,11 +305,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -326,23 +314,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes_answer/lab7_result/tools/kernel.ld
+++ b/labcodes_answer/lab7_result/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {

--- a/labcodes_answer/lab8_result/kern/init/entry.S
+++ b/labcodes_answer/lab8_result/kern/init/entry.S
@@ -6,17 +6,26 @@
 .text
 .globl kern_entry
 kern_entry:
-    # reload temperate gdt (second time) to remap all physical memory
-    # virtual_addr 0~4G=linear_addr&physical_addr -KERNBASE~4G-KERNBASE 
-    lgdt REALLOC(__gdtdesc)
-    movl $KERNEL_DS, %eax
-    movw %ax, %ds
-    movw %ax, %es
-    movw %ax, %ss
+    # load pa of boot pgdir
+    movl $REALLOC(__boot_pgdir), %eax
+    movl %eax, %cr3
 
-    ljmp $KERNEL_CS, $relocated
+    # enable paging
+    movl %cr0, %eax
+    orl $(CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP), %eax
+    andl $~(CR0_TS | CR0_EM), %eax
+    movl %eax, %cr0
 
-relocated:
+    # update eip
+    # now, eip = 0x1.....
+    leal next, %eax
+    # set eip = KERNBASE + 0x1.....
+    jmp *%eax
+next:
+
+    # unmap va 0 ~ 4M, it's temporary mapping
+    xorl %eax, %eax
+    movl %eax, __boot_pgdir
 
     # set ebp, esp
     movl $0x0, %ebp
@@ -38,12 +47,24 @@ bootstack:
     .globl bootstacktop
 bootstacktop:
 
-.align 4
-__gdt:
-    SEG_NULL
-    SEG_ASM(STA_X | STA_R, - KERNBASE, 0xFFFFFFFF)      # code segment
-    SEG_ASM(STA_W, - KERNBASE, 0xFFFFFFFF)              # data segment
-__gdtdesc:
-    .word 0x17                                          # sizeof(__gdt) - 1
-    .long REALLOC(__gdt)
+# kernel builtin pgdir
+# an initial page directory (Page Directory Table, PDT)
+# These page directory table and page table can be reused!
+.section .data.pgdir
+.align PGSIZE
+__boot_pgdir:
+.globl __boot_pgdir
+    # map va 0 ~ 4M to pa 0 ~ 4M (temporary)
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space (KERNBASE / PGSIZE / 1024 * 4) - (. - __boot_pgdir) # pad to PDE of KERNBASE
+    # map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M
+    .long REALLOC(__boot_pt1) + (PTE_P | PTE_U | PTE_W)
+    .space PGSIZE - (. - __boot_pgdir) # pad to PGSIZE
+
+.set i, 0
+__boot_pt1:
+.rept 1024
+    .long i * PGSIZE + (PTE_P | PTE_W)
+    .set i, i + 1
+.endr
 

--- a/labcodes_answer/lab8_result/kern/mm/pmm.c
+++ b/labcodes_answer/lab8_result/kern/mm/pmm.c
@@ -40,7 +40,8 @@ struct Page *pages;
 size_t npage = 0;
 
 // virtual address of boot-time page directory
-pde_t *boot_pgdir = NULL;
+extern pde_t __boot_pgdir;
+pde_t *boot_pgdir = &__boot_pgdir;
 // physical address of boot-time page directory
 uintptr_t boot_cr3;
 
@@ -252,17 +253,6 @@ page_init(void) {
     }
 }
 
-static void
-enable_paging(void) {
-    lcr3(boot_cr3);
-
-    // turn on paging
-    uint32_t cr0 = rcr0();
-    cr0 |= CR0_PE | CR0_PG | CR0_AM | CR0_WP | CR0_NE | CR0_TS | CR0_EM | CR0_MP;
-    cr0 &= ~(CR0_TS | CR0_EM);
-    lcr0(cr0);
-}
-
 //boot_map_segment - setup&enable the paging mechanism
 // parameters
 //  la:   linear address of this memory need to map (after x86 segment map)
@@ -298,6 +288,9 @@ boot_alloc_page(void) {
 //         - check the correctness of pmm & paging mechanism, print PDT&PT
 void
 pmm_init(void) {
+    // We've already enabled paging
+    boot_cr3 = PADDR(boot_pgdir);
+
     //We need to alloc/free the physical memory (granularity is 4KB or other size). 
     //So a framework of physical memory manager (struct pmm_manager)is defined in pmm.h
     //First we should init a physical memory manager(pmm) based on the framework.
@@ -312,11 +305,6 @@ pmm_init(void) {
     //use pmm->check to verify the correctness of the alloc/free function in a pmm
     check_alloc_page();
 
-    // create boot_pgdir, an initial page directory(Page Directory Table, PDT)
-    boot_pgdir = boot_alloc_page();
-    memset(boot_pgdir, 0, PGSIZE);
-    boot_cr3 = PADDR(boot_pgdir);
-
     check_pgdir();
 
     static_assert(KERNBASE % PTSIZE == 0 && KERNTOP % PTSIZE == 0);
@@ -326,23 +314,14 @@ pmm_init(void) {
     boot_pgdir[PDX(VPT)] = PADDR(boot_pgdir) | PTE_P | PTE_W;
 
     // map all physical memory to linear memory with base linear addr KERNBASE
-    //linear_addr KERNBASE~KERNBASE+KMEMSIZE = phy_addr 0~KMEMSIZE
-    //But shouldn't use this map until enable_paging() & gdt_init() finished.
+    // linear_addr KERNBASE ~ KERNBASE + KMEMSIZE = phy_addr 0 ~ KMEMSIZE
     boot_map_segment(boot_pgdir, KERNBASE, KMEMSIZE, 0, PTE_W);
 
-    //temporary map: 
-    //virtual_addr 3G~3G+4M = linear_addr 0~4M = linear_addr 3G~3G+4M = phy_addr 0~4M     
-    boot_pgdir[0] = boot_pgdir[PDX(KERNBASE)];
-
-    enable_paging();
-
-    //reload gdt(third time,the last time) to map all physical memory
-    //virtual_addr 0~4G=liear_addr 0~4G
-    //then set kernel stack(ss:esp) in TSS, setup TSS in gdt, load TSS
+    // Since we are using bootloader's GDT,
+    // we should reload gdt (second time, the last time) to get user segments and the TSS
+    // map virtual_addr 0 ~ 4G = linear_addr 0 ~ 4G
+    // then set kernel stack (ss:esp) in TSS, setup TSS in gdt, load TSS
     gdt_init();
-
-    //disable the map of virtual_addr 0~4M
-    boot_pgdir[0] = 0;
 
     //now the basic virtual memory map(see memalyout.h) is established.
     //check the correctness of the basic virtual memory map.

--- a/labcodes_answer/lab8_result/tools/kernel.ld
+++ b/labcodes_answer/lab8_result/tools/kernel.ld
@@ -44,6 +44,11 @@ SECTIONS {
         *(.data)
     }
 
+    . = ALIGN(0x1000);
+    .data.pgdir : {
+        *(.data.pgdir)
+    }
+
     PROVIDE(edata = .);
 
     .bss : {


### PR DESCRIPTION
Existing approach:

1. build and load bootloader's temporary GDT, base = 0
2. build and load kernel's temporary GDT, base = -KERNBASE (bothering)
3. build and load kernel's PDT and PT, map va 0 ~ 4M to pa 0 ~ 4M (temporary), map va KERNBASE + (0 ~ 896M) to pa 0 ~ 896M (final)
4. enable paging
5. unmap va 0 ~ 4M
6. build and load kernel's final GDT, base = 0

Our approach:

1. build and load bootloader's temporary GDT, base = 0
2. build and load kernel's PDT and PT, map va 0 ~ 4M to pa 0 ~ 4M (temporary), map va KERNBASE + (0 ~ 4M) to pa 0 ~ 4M (final)
3. enable paging
4. unmap va 0 ~ 4M
5. extra map: map va KERNBASE + (0 ~ 896M) to pa 0 ~ 896M (final)
6. build and load kernel's final GDT, base = 0