### PR TITLE
在kernel panic中添加了print_stackframe()函数

### DIFF
--- a/labcodes/lab1/kern/debug/panic.c
+++ b/labcodes/lab1/kern/debug/panic.c
@@ -22,6 +22,10 @@ __panic(const char *file, int line, const char *fmt, ...) {
     cprintf("kernel panic at %s:%d:\n    ", file, line);
     vcprintf(fmt, ap);
     cprintf("\n");
+    
+    cprintf("stack trackback:\n");
+    print_stackframe();
+    
     va_end(ap);
 
 panic_dead:

--- a/labcodes/lab2/kern/debug/panic.c
+++ b/labcodes/lab2/kern/debug/panic.c
@@ -22,6 +22,10 @@ __panic(const char *file, int line, const char *fmt, ...) {
     cprintf("kernel panic at %s:%d:\n    ", file, line);
     vcprintf(fmt, ap);
     cprintf("\n");
+    
+    cprintf("stack trackback:\n");
+    print_stackframe();
+    
     va_end(ap);
 
 panic_dead:

--- a/labcodes/lab3/kern/debug/panic.c
+++ b/labcodes/lab3/kern/debug/panic.c
@@ -22,6 +22,10 @@ __panic(const char *file, int line, const char *fmt, ...) {
     cprintf("kernel panic at %s:%d:\n    ", file, line);
     vcprintf(fmt, ap);
     cprintf("\n");
+    
+    cprintf("stack trackback:\n");
+    print_stackframe();
+    
     va_end(ap);
 
 panic_dead:

--- a/labcodes/lab4/kern/debug/panic.c
+++ b/labcodes/lab4/kern/debug/panic.c
@@ -22,6 +22,10 @@ __panic(const char *file, int line, const char *fmt, ...) {
     cprintf("kernel panic at %s:%d:\n    ", file, line);
     vcprintf(fmt, ap);
     cprintf("\n");
+    
+    cprintf("stack trackback:\n");
+    print_stackframe();
+    
     va_end(ap);
 
 panic_dead:

--- a/labcodes/lab5/kern/debug/panic.c
+++ b/labcodes/lab5/kern/debug/panic.c
@@ -22,6 +22,10 @@ __panic(const char *file, int line, const char *fmt, ...) {
     cprintf("kernel panic at %s:%d:\n    ", file, line);
     vcprintf(fmt, ap);
     cprintf("\n");
+    
+    cprintf("stack trackback:\n");
+    print_stackframe();
+    
     va_end(ap);
 
 panic_dead:

--- a/labcodes/lab6/kern/debug/panic.c
+++ b/labcodes/lab6/kern/debug/panic.c
@@ -22,6 +22,10 @@ __panic(const char *file, int line, const char *fmt, ...) {
     cprintf("kernel panic at %s:%d:\n    ", file, line);
     vcprintf(fmt, ap);
     cprintf("\n");
+    
+    cprintf("stack trackback:\n");
+    print_stackframe();
+    
     va_end(ap);
 
 panic_dead:

--- a/labcodes/lab7/kern/debug/panic.c
+++ b/labcodes/lab7/kern/debug/panic.c
@@ -22,6 +22,10 @@ __panic(const char *file, int line, const char *fmt, ...) {
     cprintf("kernel panic at %s:%d:\n    ", file, line);
     vcprintf(fmt, ap);
     cprintf("\n");
+    
+    cprintf("stack trackback:\n");
+    print_stackframe();
+    
     va_end(ap);
 
 panic_dead:

--- a/labcodes/lab8/kern/debug/panic.c
+++ b/labcodes/lab8/kern/debug/panic.c
@@ -22,6 +22,10 @@ __panic(const char *file, int line, const char *fmt, ...) {
     cprintf("kernel panic at %s:%d:\n    ", file, line);
     vcprintf(fmt, ap);
     cprintf("\n");
+    
+    cprintf("stack trackback:\n");
+    print_stackframe();
+    
     va_end(ap);
 
 panic_dead:


### PR DESCRIPTION
在kernel panic中添加了print_stackframe()函数，之前的kernel panic中只能输出panic的信息，不能很快的知道在哪里panic了，现在在panic.c中添加了lab1实现的print_stackframe()函数，可以方便调试。