### PR TITLE
Update check_sync.c

### DIFF
--- a/labcodes_answer/lab7_result/kern/sync/check_sync.c
+++ b/labcodes_answer/lab7_result/kern/sync/check_sync.c
@@ -214,9 +214,9 @@ void phi_put_forks_condvar(int i) {
       phi_test_condvar(LEFT);
       phi_test_condvar(RIGHT);
 //--------leave routine in monitor--------------
-     if(mtp->next_count>0)
-        up(&(mtp->next));
-     else
+//     if(mtp->next_count>0)
+//        up(&(mtp->next));
+//     else
         up(&(mtp->mutex));
 }
 


### PR DESCRIPTION
phi_put_forks_condvar() 中的 对于mtp->next_count>0 的判断永远为false,所以注释掉。