### PR TITLE
Fix swapfs

### DIFF
--- a/labcodes/lab3/kern/fs/swapfs.c
+++ b/labcodes/lab3/kern/fs/swapfs.c
@@ -5,6 +5,10 @@
 #include <ide.h>
 #include <pmm.h>
 #include <assert.h>
+#include <string.h>
+
+static uint32_t swapfs_bitmap[1024]; // swap is 128 MB = 32768 pages
+static size_t swapfs_nr_free;
 
 void
 swapfs_init(void) {
@@ -13,6 +17,8 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
+    memset(swapfs_bitmap, 0, sizeof(swapfs_bitmap));
+    swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 
 int
@@ -25,3 +31,27 @@ swapfs_write(swap_entry_t entry, struct Page *page) {
     return ide_write_secs(SWAP_DEV_NO, swap_offset(entry) * PAGE_NSECT, page2kva(page), PAGE_NSECT);
 }
 
+swap_entry_t
+swapfs_alloc_entry(void) {
+    if (swapfs_nr_free == 0) {
+        panic("no free space on swap fs!\n");
+    }
+
+    for (int offset = 1; offset < max_swap_offset; ++offset) {
+        if (!test_bit(offset, swapfs_bitmap)) {
+            set_bit(offset, swapfs_bitmap);
+            --swapfs_nr_free;
+            swap_entry_t entry = offset << 8;
+            return entry;
+        }
+    }
+
+    return 0;
+}
+
+void 
+swapfs_free_entry(swap_entry_t entry) {
+    size_t offset = swap_offset(entry);
+    clear_bit(offset, swapfs_bitmap);
+    ++swapfs_nr_free;
+}

--- a/labcodes/lab3/kern/fs/swapfs.h
+++ b/labcodes/lab3/kern/fs/swapfs.h
@@ -7,6 +7,8 @@
 void swapfs_init(void);
 int swapfs_read(swap_entry_t entry, struct Page *page);
 int swapfs_write(swap_entry_t entry, struct Page *page);
+swap_entry_t swapfs_alloc_entry(void);
+void swapfs_free_entry(swap_entry_t entry);
 
 #endif /* !__KERN_FS_SWAPFS_H__ */
 

--- a/labcodes/lab3/kern/mm/swap.c
+++ b/labcodes/lab3/kern/mm/swap.c
@@ -100,14 +100,16 @@ swap_out(struct mm_struct *mm, int n, int in_tick)
           pte_t *ptep = get_pte(mm->pgdir, v, 0);
           assert((*ptep & PTE_P) != 0);
 
-          if (swapfs_write( (page->pra_vaddr/PGSIZE+1)<<8, page) != 0) {
+          swap_entry_t entry = swapfs_alloc_entry();
+
+          if (swapfs_write(entry, page) != 0) {
                     cprintf("SWAP: failed to save\n");
                     sm->map_swappable(mm, v, page, 0);
                     continue;
           }
           else {
-                    cprintf("swap_out: i %d, store page in vaddr 0x%x to disk swap entry %d\n", i, v, page->pra_vaddr/PGSIZE+1);
-                    *ptep = (page->pra_vaddr/PGSIZE+1)<<8;
+                    cprintf("swap_out: i %d, store page in vaddr 0x%x to disk swap entry %d\n", i, v, swap_offset(entry));
+                    *ptep = entry;
                     free_page(page);
           }
           
@@ -132,6 +134,7 @@ swap_in(struct mm_struct *mm, uintptr_t addr, struct Page **ptr_result)
      }
      cprintf("swap_in: load disk swap entry %d with swap_page in vadr 0x%x\n", (*ptep)>>8, addr);
      *ptr_result=result;
+     swapfs_free_entry(*ptep);
      return 0;
 }
 

--- a/labcodes/lab4/kern/fs/swapfs.c
+++ b/labcodes/lab4/kern/fs/swapfs.c
@@ -18,8 +18,8 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
-    swapfs_bitmap = kmalloc(max_swap_offset / 8);
-    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_bitmap = kmalloc((max_swap_offset + 7) / 8);
+    memset(swapfs_bitmap, 0, (max_swap_offset + 7) / 8);
     swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 

--- a/labcodes/lab4/kern/fs/swapfs.c
+++ b/labcodes/lab4/kern/fs/swapfs.c
@@ -5,6 +5,11 @@
 #include <ide.h>
 #include <pmm.h>
 #include <assert.h>
+#include <string.h>
+#include <kmalloc.h>
+
+static uint32_t *swapfs_bitmap;
+static size_t swapfs_nr_free;
 
 void
 swapfs_init(void) {
@@ -13,6 +18,9 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
+    swapfs_bitmap = kmalloc(max_swap_offset / 8);
+    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 
 int
@@ -25,3 +33,27 @@ swapfs_write(swap_entry_t entry, struct Page *page) {
     return ide_write_secs(SWAP_DEV_NO, swap_offset(entry) * PAGE_NSECT, page2kva(page), PAGE_NSECT);
 }
 
+swap_entry_t
+swapfs_alloc_entry(void) {
+    if (swapfs_nr_free == 0) {
+        panic("no free space on swap fs!\n");
+    }
+
+    for (int offset = 1; offset < max_swap_offset; ++offset) {
+        if (!test_bit(offset, swapfs_bitmap)) {
+            set_bit(offset, swapfs_bitmap);
+            --swapfs_nr_free;
+            swap_entry_t entry = offset << 8;
+            return entry;
+        }
+    }
+
+    return 0;
+}
+
+void 
+swapfs_free_entry(swap_entry_t entry) {
+    size_t offset = swap_offset(entry);
+    clear_bit(offset, swapfs_bitmap);
+    ++swapfs_nr_free;
+}

--- a/labcodes/lab4/kern/fs/swapfs.h
+++ b/labcodes/lab4/kern/fs/swapfs.h
@@ -7,6 +7,7 @@
 void swapfs_init(void);
 int swapfs_read(swap_entry_t entry, struct Page *page);
 int swapfs_write(swap_entry_t entry, struct Page *page);
+swap_entry_t swapfs_alloc_entry(void);
+void swapfs_free_entry(swap_entry_t entry);
 
 #endif /* !__KERN_FS_SWAPFS_H__ */
-

--- a/labcodes/lab4/kern/mm/swap.c
+++ b/labcodes/lab4/kern/mm/swap.c
@@ -100,14 +100,16 @@ swap_out(struct mm_struct *mm, int n, int in_tick)
           pte_t *ptep = get_pte(mm->pgdir, v, 0);
           assert((*ptep & PTE_P) != 0);
 
-          if (swapfs_write( (page->pra_vaddr/PGSIZE+1)<<8, page) != 0) {
+          swap_entry_t entry = swapfs_alloc_entry();
+
+          if (swapfs_write(entry, page) != 0) {
                     cprintf("SWAP: failed to save\n");
                     sm->map_swappable(mm, v, page, 0);
                     continue;
           }
           else {
-                    cprintf("swap_out: i %d, store page in vaddr 0x%x to disk swap entry %d\n", i, v, page->pra_vaddr/PGSIZE+1);
-                    *ptep = (page->pra_vaddr/PGSIZE+1)<<8;
+                    cprintf("swap_out: i %d, store page in vaddr 0x%x to disk swap entry %d\n", i, v, swap_offset(entry));
+                    *ptep = entry;
                     free_page(page);
           }
           
@@ -132,6 +134,7 @@ swap_in(struct mm_struct *mm, uintptr_t addr, struct Page **ptr_result)
      }
      cprintf("swap_in: load disk swap entry %d with swap_page in vadr 0x%x\n", (*ptep)>>8, addr);
      *ptr_result=result;
+     swapfs_free_entry(*ptep);
      return 0;
 }
 

--- a/labcodes/lab5/kern/fs/swapfs.c
+++ b/labcodes/lab5/kern/fs/swapfs.c
@@ -18,8 +18,8 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
-    swapfs_bitmap = kmalloc(max_swap_offset / 8);
-    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_bitmap = kmalloc((max_swap_offset + 7) / 8);
+    memset(swapfs_bitmap, 0, (max_swap_offset + 7) / 8);
     swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 

--- a/labcodes/lab5/kern/fs/swapfs.c
+++ b/labcodes/lab5/kern/fs/swapfs.c
@@ -5,6 +5,11 @@
 #include <ide.h>
 #include <pmm.h>
 #include <assert.h>
+#include <string.h>
+#include <kmalloc.h>
+
+static uint32_t *swapfs_bitmap;
+static size_t swapfs_nr_free;
 
 void
 swapfs_init(void) {
@@ -13,6 +18,9 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
+    swapfs_bitmap = kmalloc(max_swap_offset / 8);
+    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 
 int
@@ -25,3 +33,27 @@ swapfs_write(swap_entry_t entry, struct Page *page) {
     return ide_write_secs(SWAP_DEV_NO, swap_offset(entry) * PAGE_NSECT, page2kva(page), PAGE_NSECT);
 }
 
+swap_entry_t
+swapfs_alloc_entry(void) {
+    if (swapfs_nr_free == 0) {
+        panic("no free space on swap fs!\n");
+    }
+
+    for (int offset = 1; offset < max_swap_offset; ++offset) {
+        if (!test_bit(offset, swapfs_bitmap)) {
+            set_bit(offset, swapfs_bitmap);
+            --swapfs_nr_free;
+            swap_entry_t entry = offset << 8;
+            return entry;
+        }
+    }
+
+    return 0;
+}
+
+void 
+swapfs_free_entry(swap_entry_t entry) {
+    size_t offset = swap_offset(entry);
+    clear_bit(offset, swapfs_bitmap);
+    ++swapfs_nr_free;
+}

--- a/labcodes/lab5/kern/fs/swapfs.h
+++ b/labcodes/lab5/kern/fs/swapfs.h
@@ -7,6 +7,7 @@
 void swapfs_init(void);
 int swapfs_read(swap_entry_t entry, struct Page *page);
 int swapfs_write(swap_entry_t entry, struct Page *page);
+swap_entry_t swapfs_alloc_entry(void);
+void swapfs_free_entry(swap_entry_t entry);
 
 #endif /* !__KERN_FS_SWAPFS_H__ */
-

--- a/labcodes/lab5/kern/mm/pmm.c
+++ b/labcodes/lab5/kern/mm/pmm.c
@@ -11,6 +11,7 @@
 #include <swap.h>
 #include <vmm.h>
 #include <kmalloc.h>
+#include <proc.h>
 
 /* *
  * Task State Segment:
@@ -573,10 +574,10 @@ pgdir_alloc_page(pde_t *pgdir, uintptr_t la, uint32_t perm) {
                 assert(page_ref(page) == 1);
                 //cprintf("get No. %d  page: pra_vaddr %x, pra_link.prev %x, pra_link_next %x in pgdir_alloc_page\n", (page-pages), page->pra_vaddr,page->pra_page_link.prev, page->pra_page_link.next);
             } 
-            else  {  //now current is existed, should fix it in the future
-                //swap_map_swappable(current->mm, la, page, 0);
-                //page->pra_vaddr=la;
-                //assert(page_ref(page) == 1);
+            else if (current->mm)  {  //now current is existed, should fix it in the future
+                swap_map_swappable(current->mm, la, page, 0);
+                page->pra_vaddr=la;
+                assert(page_ref(page) == 1);
                 //panic("pgdir_alloc_page: no pages. now current is existed, should fix it in the future\n");
             }
         }

--- a/labcodes/lab6/kern/fs/swapfs.c
+++ b/labcodes/lab6/kern/fs/swapfs.c
@@ -18,8 +18,8 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
-    swapfs_bitmap = kmalloc(max_swap_offset / 8);
-    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_bitmap = kmalloc((max_swap_offset + 7) / 8);
+    memset(swapfs_bitmap, 0, (max_swap_offset + 7) / 8);
     swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 

--- a/labcodes/lab6/kern/fs/swapfs.c
+++ b/labcodes/lab6/kern/fs/swapfs.c
@@ -5,6 +5,11 @@
 #include <ide.h>
 #include <pmm.h>
 #include <assert.h>
+#include <string.h>
+#include <kmalloc.h>
+
+static uint32_t *swapfs_bitmap;
+static size_t swapfs_nr_free;
 
 void
 swapfs_init(void) {
@@ -13,6 +18,9 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
+    swapfs_bitmap = kmalloc(max_swap_offset / 8);
+    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 
 int
@@ -25,3 +33,27 @@ swapfs_write(swap_entry_t entry, struct Page *page) {
     return ide_write_secs(SWAP_DEV_NO, swap_offset(entry) * PAGE_NSECT, page2kva(page), PAGE_NSECT);
 }
 
+swap_entry_t
+swapfs_alloc_entry(void) {
+    if (swapfs_nr_free == 0) {
+        panic("no free space on swap fs!\n");
+    }
+
+    for (int offset = 1; offset < max_swap_offset; ++offset) {
+        if (!test_bit(offset, swapfs_bitmap)) {
+            set_bit(offset, swapfs_bitmap);
+            --swapfs_nr_free;
+            swap_entry_t entry = offset << 8;
+            return entry;
+        }
+    }
+
+    return 0;
+}
+
+void 
+swapfs_free_entry(swap_entry_t entry) {
+    size_t offset = swap_offset(entry);
+    clear_bit(offset, swapfs_bitmap);
+    ++swapfs_nr_free;
+}

--- a/labcodes/lab6/kern/fs/swapfs.h
+++ b/labcodes/lab6/kern/fs/swapfs.h
@@ -7,6 +7,7 @@
 void swapfs_init(void);
 int swapfs_read(swap_entry_t entry, struct Page *page);
 int swapfs_write(swap_entry_t entry, struct Page *page);
+swap_entry_t swapfs_alloc_entry(void);
+void swapfs_free_entry(swap_entry_t entry);
 
 #endif /* !__KERN_FS_SWAPFS_H__ */
-

--- a/labcodes/lab6/kern/mm/pmm.c
+++ b/labcodes/lab6/kern/mm/pmm.c
@@ -11,6 +11,7 @@
 #include <swap.h>
 #include <vmm.h>
 #include <kmalloc.h>
+#include <proc.h>
 
 /* *
  * Task State Segment:
@@ -573,10 +574,10 @@ pgdir_alloc_page(pde_t *pgdir, uintptr_t la, uint32_t perm) {
                 assert(page_ref(page) == 1);
                 //cprintf("get No. %d  page: pra_vaddr %x, pra_link.prev %x, pra_link_next %x in pgdir_alloc_page\n", (page-pages), page->pra_vaddr,page->pra_page_link.prev, page->pra_page_link.next);
             } 
-            else  {  //now current is existed, should fix it in the future
-                //swap_map_swappable(current->mm, la, page, 0);
-                //page->pra_vaddr=la;
-                //assert(page_ref(page) == 1);
+            else if (current->mm) {  //now current is existed, should fix it in the future
+                swap_map_swappable(current->mm, la, page, 0);
+                page->pra_vaddr=la;
+                assert(page_ref(page) == 1);
                 //panic("pgdir_alloc_page: no pages. now current is existed, should fix it in the future\n");
             }
         }

--- a/labcodes/lab7/kern/fs/swapfs.c
+++ b/labcodes/lab7/kern/fs/swapfs.c
@@ -18,8 +18,8 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
-    swapfs_bitmap = kmalloc(max_swap_offset / 8);
-    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_bitmap = kmalloc((max_swap_offset + 7) / 8);
+    memset(swapfs_bitmap, 0, (max_swap_offset + 7) / 8);
     swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 

--- a/labcodes/lab7/kern/fs/swapfs.c
+++ b/labcodes/lab7/kern/fs/swapfs.c
@@ -5,6 +5,11 @@
 #include <ide.h>
 #include <pmm.h>
 #include <assert.h>
+#include <string.h>
+#include <kmalloc.h>
+
+static uint32_t *swapfs_bitmap;
+static size_t swapfs_nr_free;
 
 void
 swapfs_init(void) {
@@ -13,6 +18,9 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
+    swapfs_bitmap = kmalloc(max_swap_offset / 8);
+    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 
 int
@@ -25,3 +33,27 @@ swapfs_write(swap_entry_t entry, struct Page *page) {
     return ide_write_secs(SWAP_DEV_NO, swap_offset(entry) * PAGE_NSECT, page2kva(page), PAGE_NSECT);
 }
 
+swap_entry_t
+swapfs_alloc_entry(void) {
+    if (swapfs_nr_free == 0) {
+        panic("no free space on swap fs!\n");
+    }
+
+    for (int offset = 1; offset < max_swap_offset; ++offset) {
+        if (!test_bit(offset, swapfs_bitmap)) {
+            set_bit(offset, swapfs_bitmap);
+            --swapfs_nr_free;
+            swap_entry_t entry = offset << 8;
+            return entry;
+        }
+    }
+
+    return 0;
+}
+
+void 
+swapfs_free_entry(swap_entry_t entry) {
+    size_t offset = swap_offset(entry);
+    clear_bit(offset, swapfs_bitmap);
+    ++swapfs_nr_free;
+}

--- a/labcodes/lab7/kern/fs/swapfs.h
+++ b/labcodes/lab7/kern/fs/swapfs.h
@@ -7,6 +7,7 @@
 void swapfs_init(void);
 int swapfs_read(swap_entry_t entry, struct Page *page);
 int swapfs_write(swap_entry_t entry, struct Page *page);
+swap_entry_t swapfs_alloc_entry(void);
+void swapfs_free_entry(swap_entry_t entry);
 
 #endif /* !__KERN_FS_SWAPFS_H__ */
-

--- a/labcodes/lab7/kern/mm/pmm.c
+++ b/labcodes/lab7/kern/mm/pmm.c
@@ -11,6 +11,7 @@
 #include <swap.h>
 #include <vmm.h>
 #include <kmalloc.h>
+#include <proc.h>
 
 /* *
  * Task State Segment:
@@ -573,10 +574,10 @@ pgdir_alloc_page(pde_t *pgdir, uintptr_t la, uint32_t perm) {
                 assert(page_ref(page) == 1);
                 //cprintf("get No. %d  page: pra_vaddr %x, pra_link.prev %x, pra_link_next %x in pgdir_alloc_page\n", (page-pages), page->pra_vaddr,page->pra_page_link.prev, page->pra_page_link.next);
             } 
-            else  {  //now current is existed, should fix it in the future
-                //swap_map_swappable(current->mm, la, page, 0);
-                //page->pra_vaddr=la;
-                //assert(page_ref(page) == 1);
+            else if (current->mm) {  //now current is existed, should fix it in the future
+                swap_map_swappable(current->mm, la, page, 0);
+                page->pra_vaddr=la;
+                assert(page_ref(page) == 1);
                 //panic("pgdir_alloc_page: no pages. now current is existed, should fix it in the future\n");
             }
         }

--- a/labcodes/lab8/kern/fs/swap/swapfs.c
+++ b/labcodes/lab8/kern/fs/swap/swapfs.c
@@ -18,8 +18,8 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
-    swapfs_bitmap = kmalloc(max_swap_offset / 8);
-    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_bitmap = kmalloc((max_swap_offset + 7) / 8);
+    memset(swapfs_bitmap, 0, (max_swap_offset + 7) / 8);
     swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 

--- a/labcodes/lab8/kern/fs/swap/swapfs.c
+++ b/labcodes/lab8/kern/fs/swap/swapfs.c
@@ -5,6 +5,11 @@
 #include <ide.h>
 #include <pmm.h>
 #include <assert.h>
+#include <string.h>
+#include <kmalloc.h>
+
+static uint32_t *swapfs_bitmap;
+static size_t swapfs_nr_free;
 
 void
 swapfs_init(void) {
@@ -13,6 +18,9 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
+    swapfs_bitmap = kmalloc(max_swap_offset / 8);
+    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 
 int
@@ -25,3 +33,27 @@ swapfs_write(swap_entry_t entry, struct Page *page) {
     return ide_write_secs(SWAP_DEV_NO, swap_offset(entry) * PAGE_NSECT, page2kva(page), PAGE_NSECT);
 }
 
+swap_entry_t
+swapfs_alloc_entry(void) {
+    if (swapfs_nr_free == 0) {
+        panic("no free space on swap fs!\n");
+    }
+
+    for (int offset = 1; offset < max_swap_offset; ++offset) {
+        if (!test_bit(offset, swapfs_bitmap)) {
+            set_bit(offset, swapfs_bitmap);
+            --swapfs_nr_free;
+            swap_entry_t entry = offset << 8;
+            return entry;
+        }
+    }
+
+    return 0;
+}
+
+void 
+swapfs_free_entry(swap_entry_t entry) {
+    size_t offset = swap_offset(entry);
+    clear_bit(offset, swapfs_bitmap);
+    ++swapfs_nr_free;
+}

--- a/labcodes/lab8/kern/fs/swap/swapfs.h
+++ b/labcodes/lab8/kern/fs/swap/swapfs.h
@@ -1,5 +1,5 @@
-#ifndef __KERN_FS_SWAP_SWAPFS_H__
-#define __KERN_FS_SWAP_SWAPFS_H__
+#ifndef __KERN_FS_SWAPFS_H__
+#define __KERN_FS_SWAPFS_H__
 
 #include <memlayout.h>
 #include <swap.h>
@@ -7,6 +7,7 @@
 void swapfs_init(void);
 int swapfs_read(swap_entry_t entry, struct Page *page);
 int swapfs_write(swap_entry_t entry, struct Page *page);
+swap_entry_t swapfs_alloc_entry(void);
+void swapfs_free_entry(swap_entry_t entry);
 
-#endif /* !__KERN_FS_SWAP_SWAPFS_H__ */
-
+#endif /* !__KERN_FS_SWAPFS_H__ */

--- a/labcodes/lab8/kern/mm/pmm.c
+++ b/labcodes/lab8/kern/mm/pmm.c
@@ -11,6 +11,7 @@
 #include <swap.h>
 #include <vmm.h>
 #include <kmalloc.h>
+#include <proc.h>
 
 /* *
  * Task State Segment:
@@ -573,10 +574,10 @@ pgdir_alloc_page(pde_t *pgdir, uintptr_t la, uint32_t perm) {
                 assert(page_ref(page) == 1);
                 //cprintf("get No. %d  page: pra_vaddr %x, pra_link.prev %x, pra_link_next %x in pgdir_alloc_page\n", (page-pages), page->pra_vaddr,page->pra_page_link.prev, page->pra_page_link.next);
             } 
-            else  {  //now current is existed, should fix it in the future
-                //swap_map_swappable(current->mm, la, page, 0);
-                //page->pra_vaddr=la;
-                //assert(page_ref(page) == 1);
+            else if (current->mm) {  //now current is existed, should fix it in the future
+                swap_map_swappable(current->mm, la, page, 0);
+                page->pra_vaddr=la;
+                assert(page_ref(page) == 1);
                 //panic("pgdir_alloc_page: no pages. now current is existed, should fix it in the future\n");
             }
         }

--- a/labcodes_answer/lab3_result/kern/fs/swapfs.c
+++ b/labcodes_answer/lab3_result/kern/fs/swapfs.c
@@ -5,6 +5,10 @@
 #include <ide.h>
 #include <pmm.h>
 #include <assert.h>
+#include <string.h>
+
+static uint32_t swapfs_bitmap[1024]; // swap is 128 MB = 32768 pages
+static size_t swapfs_nr_free;
 
 void
 swapfs_init(void) {
@@ -13,6 +17,8 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
+    memset(swapfs_bitmap, 0, sizeof(swapfs_bitmap));
+    swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 
 int
@@ -25,3 +31,27 @@ swapfs_write(swap_entry_t entry, struct Page *page) {
     return ide_write_secs(SWAP_DEV_NO, swap_offset(entry) * PAGE_NSECT, page2kva(page), PAGE_NSECT);
 }
 
+swap_entry_t
+swapfs_alloc_entry(void) {
+    if (swapfs_nr_free == 0) {
+        panic("no free space on swap fs!\n");
+    }
+
+    for (int offset = 1; offset < max_swap_offset; ++offset) {
+        if (!test_bit(offset, swapfs_bitmap)) {
+            set_bit(offset, swapfs_bitmap);
+            --swapfs_nr_free;
+            swap_entry_t entry = offset << 8;
+            return entry;
+        }
+    }
+
+    return 0;
+}
+
+void 
+swapfs_free_entry(swap_entry_t entry) {
+    size_t offset = swap_offset(entry);
+    clear_bit(offset, swapfs_bitmap);
+    ++swapfs_nr_free;
+}

--- a/labcodes_answer/lab3_result/kern/fs/swapfs.h
+++ b/labcodes_answer/lab3_result/kern/fs/swapfs.h
@@ -7,6 +7,8 @@
 void swapfs_init(void);
 int swapfs_read(swap_entry_t entry, struct Page *page);
 int swapfs_write(swap_entry_t entry, struct Page *page);
+swap_entry_t swapfs_alloc_entry(void);
+void swapfs_free_entry(swap_entry_t entry);
 
 #endif /* !__KERN_FS_SWAPFS_H__ */
 

--- a/labcodes_answer/lab3_result/kern/mm/swap.c
+++ b/labcodes_answer/lab3_result/kern/mm/swap.c
@@ -100,14 +100,16 @@ swap_out(struct mm_struct *mm, int n, int in_tick)
           pte_t *ptep = get_pte(mm->pgdir, v, 0);
           assert((*ptep & PTE_P) != 0);
 
-          if (swapfs_write( (page->pra_vaddr/PGSIZE+1)<<8, page) != 0) {
+          swap_entry_t entry = swapfs_alloc_entry();
+
+          if (swapfs_write(entry, page) != 0) {
                     cprintf("SWAP: failed to save\n");
                     sm->map_swappable(mm, v, page, 0);
                     continue;
           }
           else {
-                    cprintf("swap_out: i %d, store page in vaddr 0x%x to disk swap entry %d\n", i, v, page->pra_vaddr/PGSIZE+1);
-                    *ptep = (page->pra_vaddr/PGSIZE+1)<<8;
+                    cprintf("swap_out: i %d, store page in vaddr 0x%x to disk swap entry %d\n", i, v, swap_offset(entry));
+                    *ptep = entry;
                     free_page(page);
           }
           
@@ -132,6 +134,7 @@ swap_in(struct mm_struct *mm, uintptr_t addr, struct Page **ptr_result)
      }
      cprintf("swap_in: load disk swap entry %d with swap_page in vadr 0x%x\n", (*ptep)>>8, addr);
      *ptr_result=result;
+     swapfs_free_entry(*ptep);
      return 0;
 }
 

--- a/labcodes_answer/lab4_result/kern/fs/swapfs.c
+++ b/labcodes_answer/lab4_result/kern/fs/swapfs.c
@@ -18,8 +18,8 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
-    swapfs_bitmap = kmalloc(max_swap_offset / 8);
-    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_bitmap = kmalloc((max_swap_offset + 7) / 8);
+    memset(swapfs_bitmap, 0, (max_swap_offset + 7) / 8);
     swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 

--- a/labcodes_answer/lab4_result/kern/fs/swapfs.c
+++ b/labcodes_answer/lab4_result/kern/fs/swapfs.c
@@ -5,6 +5,11 @@
 #include <ide.h>
 #include <pmm.h>
 #include <assert.h>
+#include <string.h>
+#include <kmalloc.h>
+
+static uint32_t *swapfs_bitmap;
+static size_t swapfs_nr_free;
 
 void
 swapfs_init(void) {
@@ -13,6 +18,9 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
+    swapfs_bitmap = kmalloc(max_swap_offset / 8);
+    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 
 int
@@ -25,3 +33,27 @@ swapfs_write(swap_entry_t entry, struct Page *page) {
     return ide_write_secs(SWAP_DEV_NO, swap_offset(entry) * PAGE_NSECT, page2kva(page), PAGE_NSECT);
 }
 
+swap_entry_t
+swapfs_alloc_entry(void) {
+    if (swapfs_nr_free == 0) {
+        panic("no free space on swap fs!\n");
+    }
+
+    for (int offset = 1; offset < max_swap_offset; ++offset) {
+        if (!test_bit(offset, swapfs_bitmap)) {
+            set_bit(offset, swapfs_bitmap);
+            --swapfs_nr_free;
+            swap_entry_t entry = offset << 8;
+            return entry;
+        }
+    }
+
+    return 0;
+}
+
+void 
+swapfs_free_entry(swap_entry_t entry) {
+    size_t offset = swap_offset(entry);
+    clear_bit(offset, swapfs_bitmap);
+    ++swapfs_nr_free;
+}

--- a/labcodes_answer/lab4_result/kern/fs/swapfs.h
+++ b/labcodes_answer/lab4_result/kern/fs/swapfs.h
@@ -7,6 +7,7 @@
 void swapfs_init(void);
 int swapfs_read(swap_entry_t entry, struct Page *page);
 int swapfs_write(swap_entry_t entry, struct Page *page);
+swap_entry_t swapfs_alloc_entry(void);
+void swapfs_free_entry(swap_entry_t entry);
 
 #endif /* !__KERN_FS_SWAPFS_H__ */
-

--- a/labcodes_answer/lab4_result/kern/mm/swap.c
+++ b/labcodes_answer/lab4_result/kern/mm/swap.c
@@ -100,14 +100,16 @@ swap_out(struct mm_struct *mm, int n, int in_tick)
           pte_t *ptep = get_pte(mm->pgdir, v, 0);
           assert((*ptep & PTE_P) != 0);
 
-          if (swapfs_write( (page->pra_vaddr/PGSIZE+1)<<8, page) != 0) {
+          swap_entry_t entry = swapfs_alloc_entry();
+
+          if (swapfs_write(entry, page) != 0) {
                     cprintf("SWAP: failed to save\n");
                     sm->map_swappable(mm, v, page, 0);
                     continue;
           }
           else {
-                    cprintf("swap_out: i %d, store page in vaddr 0x%x to disk swap entry %d\n", i, v, page->pra_vaddr/PGSIZE+1);
-                    *ptep = (page->pra_vaddr/PGSIZE+1)<<8;
+                    cprintf("swap_out: i %d, store page in vaddr 0x%x to disk swap entry %d\n", i, v, swap_offset(entry));
+                    *ptep = entry;
                     free_page(page);
           }
           
@@ -132,6 +134,7 @@ swap_in(struct mm_struct *mm, uintptr_t addr, struct Page **ptr_result)
      }
      cprintf("swap_in: load disk swap entry %d with swap_page in vadr 0x%x\n", (*ptep)>>8, addr);
      *ptr_result=result;
+     swapfs_free_entry(*ptep);
      return 0;
 }
 

--- a/labcodes_answer/lab5_result/kern/fs/swapfs.c
+++ b/labcodes_answer/lab5_result/kern/fs/swapfs.c
@@ -18,8 +18,8 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
-    swapfs_bitmap = kmalloc(max_swap_offset / 8);
-    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_bitmap = kmalloc((max_swap_offset + 7) / 8);
+    memset(swapfs_bitmap, 0, (max_swap_offset + 7) / 8);
     swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 

--- a/labcodes_answer/lab5_result/kern/fs/swapfs.c
+++ b/labcodes_answer/lab5_result/kern/fs/swapfs.c
@@ -5,6 +5,11 @@
 #include <ide.h>
 #include <pmm.h>
 #include <assert.h>
+#include <string.h>
+#include <kmalloc.h>
+
+static uint32_t *swapfs_bitmap;
+static size_t swapfs_nr_free;
 
 void
 swapfs_init(void) {
@@ -13,6 +18,9 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
+    swapfs_bitmap = kmalloc(max_swap_offset / 8);
+    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 
 int
@@ -25,3 +33,27 @@ swapfs_write(swap_entry_t entry, struct Page *page) {
     return ide_write_secs(SWAP_DEV_NO, swap_offset(entry) * PAGE_NSECT, page2kva(page), PAGE_NSECT);
 }
 
+swap_entry_t
+swapfs_alloc_entry(void) {
+    if (swapfs_nr_free == 0) {
+        panic("no free space on swap fs!\n");
+    }
+
+    for (int offset = 1; offset < max_swap_offset; ++offset) {
+        if (!test_bit(offset, swapfs_bitmap)) {
+            set_bit(offset, swapfs_bitmap);
+            --swapfs_nr_free;
+            swap_entry_t entry = offset << 8;
+            return entry;
+        }
+    }
+
+    return 0;
+}
+
+void 
+swapfs_free_entry(swap_entry_t entry) {
+    size_t offset = swap_offset(entry);
+    clear_bit(offset, swapfs_bitmap);
+    ++swapfs_nr_free;
+}

--- a/labcodes_answer/lab5_result/kern/fs/swapfs.h
+++ b/labcodes_answer/lab5_result/kern/fs/swapfs.h
@@ -7,6 +7,7 @@
 void swapfs_init(void);
 int swapfs_read(swap_entry_t entry, struct Page *page);
 int swapfs_write(swap_entry_t entry, struct Page *page);
+swap_entry_t swapfs_alloc_entry(void);
+void swapfs_free_entry(swap_entry_t entry);
 
 #endif /* !__KERN_FS_SWAPFS_H__ */
-

--- a/labcodes_answer/lab5_result/kern/mm/pmm.c
+++ b/labcodes_answer/lab5_result/kern/mm/pmm.c
@@ -11,6 +11,7 @@
 #include <swap.h>
 #include <vmm.h>
 #include <kmalloc.h>
+#include <proc.h>
 
 /* *
  * Task State Segment:
@@ -599,10 +600,10 @@ pgdir_alloc_page(pde_t *pgdir, uintptr_t la, uint32_t perm) {
                 assert(page_ref(page) == 1);
                 //cprintf("get No. %d  page: pra_vaddr %x, pra_link.prev %x, pra_link_next %x in pgdir_alloc_page\n", (page-pages), page->pra_vaddr,page->pra_page_link.prev, page->pra_page_link.next);
             } 
-            else  {  //now current is existed, should fix it in the future
-                //swap_map_swappable(current->mm, la, page, 0);
-                //page->pra_vaddr=la;
-                //assert(page_ref(page) == 1);
+            else if(current->mm) {  //now current is existed, should fix it in the future
+                swap_map_swappable(current->mm, la, page, 0);
+                page->pra_vaddr=la;
+                assert(page_ref(page) == 1);
                 //panic("pgdir_alloc_page: no pages. now current is existed, should fix it in the future\n");
             }
         }

--- a/labcodes_answer/lab5_result/kern/mm/swap.c
+++ b/labcodes_answer/lab5_result/kern/mm/swap.c
@@ -265,8 +265,11 @@ check_swap(void)
      } 
 
      //free_page(pte2page(*temp_ptep));
-     
+    free_page(pde2page(pgdir[0]));
+     pgdir[0] = 0;
+     mm->pgdir = NULL;
      mm_destroy(mm);
+     check_mm_struct = NULL;
          
      nr_free = nr_free_store;
      free_list = free_list_store;

--- a/labcodes_answer/lab6_result/kern/fs/swapfs.c
+++ b/labcodes_answer/lab6_result/kern/fs/swapfs.c
@@ -18,8 +18,8 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
-    swapfs_bitmap = kmalloc(max_swap_offset / 8);
-    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_bitmap = kmalloc((max_swap_offset + 7) / 8);
+    memset(swapfs_bitmap, 0, (max_swap_offset + 7) / 8);
     swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 

--- a/labcodes_answer/lab6_result/kern/fs/swapfs.c
+++ b/labcodes_answer/lab6_result/kern/fs/swapfs.c
@@ -5,6 +5,11 @@
 #include <ide.h>
 #include <pmm.h>
 #include <assert.h>
+#include <string.h>
+#include <kmalloc.h>
+
+static uint32_t *swapfs_bitmap;
+static size_t swapfs_nr_free;
 
 void
 swapfs_init(void) {
@@ -13,6 +18,9 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
+    swapfs_bitmap = kmalloc(max_swap_offset / 8);
+    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 
 int
@@ -25,3 +33,27 @@ swapfs_write(swap_entry_t entry, struct Page *page) {
     return ide_write_secs(SWAP_DEV_NO, swap_offset(entry) * PAGE_NSECT, page2kva(page), PAGE_NSECT);
 }
 
+swap_entry_t
+swapfs_alloc_entry(void) {
+    if (swapfs_nr_free == 0) {
+        panic("no free space on swap fs!\n");
+    }
+
+    for (int offset = 1; offset < max_swap_offset; ++offset) {
+        if (!test_bit(offset, swapfs_bitmap)) {
+            set_bit(offset, swapfs_bitmap);
+            --swapfs_nr_free;
+            swap_entry_t entry = offset << 8;
+            return entry;
+        }
+    }
+
+    return 0;
+}
+
+void 
+swapfs_free_entry(swap_entry_t entry) {
+    size_t offset = swap_offset(entry);
+    clear_bit(offset, swapfs_bitmap);
+    ++swapfs_nr_free;
+}

--- a/labcodes_answer/lab6_result/kern/fs/swapfs.h
+++ b/labcodes_answer/lab6_result/kern/fs/swapfs.h
@@ -7,6 +7,7 @@
 void swapfs_init(void);
 int swapfs_read(swap_entry_t entry, struct Page *page);
 int swapfs_write(swap_entry_t entry, struct Page *page);
+swap_entry_t swapfs_alloc_entry(void);
+void swapfs_free_entry(swap_entry_t entry);
 
 #endif /* !__KERN_FS_SWAPFS_H__ */
-

--- a/labcodes_answer/lab6_result/kern/mm/pmm.c
+++ b/labcodes_answer/lab6_result/kern/mm/pmm.c
@@ -11,6 +11,7 @@
 #include <swap.h>
 #include <vmm.h>
 #include <kmalloc.h>
+#include <proc.h>
 
 /* *
  * Task State Segment:
@@ -599,10 +600,10 @@ pgdir_alloc_page(pde_t *pgdir, uintptr_t la, uint32_t perm) {
                 assert(page_ref(page) == 1);
                 //cprintf("get No. %d  page: pra_vaddr %x, pra_link.prev %x, pra_link_next %x in pgdir_alloc_page\n", (page-pages), page->pra_vaddr,page->pra_page_link.prev, page->pra_page_link.next);
             } 
-            else  {  //now current is existed, should fix it in the future
-                //swap_map_swappable(current->mm, la, page, 0);
-                //page->pra_vaddr=la;
-                //assert(page_ref(page) == 1);
+            else if (current->mm) {  //now current is existed, should fix it in the future
+                swap_map_swappable(current->mm, la, page, 0);
+                page->pra_vaddr=la;
+                assert(page_ref(page) == 1);
                 //panic("pgdir_alloc_page: no pages. now current is existed, should fix it in the future\n");
             }
         }

--- a/labcodes_answer/lab6_result/kern/mm/swap.c
+++ b/labcodes_answer/lab6_result/kern/mm/swap.c
@@ -265,8 +265,11 @@ check_swap(void)
      } 
 
      //free_page(pte2page(*temp_ptep));
-     
+    free_page(pde2page(pgdir[0]));
+     pgdir[0] = 0;
+     mm->pgdir = NULL;
      mm_destroy(mm);
+     check_mm_struct = NULL;
          
      nr_free = nr_free_store;
      free_list = free_list_store;

--- a/labcodes_answer/lab7_result/kern/fs/swapfs.c
+++ b/labcodes_answer/lab7_result/kern/fs/swapfs.c
@@ -18,8 +18,8 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
-    swapfs_bitmap = kmalloc(max_swap_offset / 8);
-    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_bitmap = kmalloc((max_swap_offset + 7) / 8);
+    memset(swapfs_bitmap, 0, (max_swap_offset + 7) / 8);
     swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 

--- a/labcodes_answer/lab7_result/kern/fs/swapfs.c
+++ b/labcodes_answer/lab7_result/kern/fs/swapfs.c
@@ -5,6 +5,11 @@
 #include <ide.h>
 #include <pmm.h>
 #include <assert.h>
+#include <string.h>
+#include <kmalloc.h>
+
+static uint32_t *swapfs_bitmap;
+static size_t swapfs_nr_free;
 
 void
 swapfs_init(void) {
@@ -13,6 +18,9 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
+    swapfs_bitmap = kmalloc(max_swap_offset / 8);
+    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 
 int
@@ -25,3 +33,27 @@ swapfs_write(swap_entry_t entry, struct Page *page) {
     return ide_write_secs(SWAP_DEV_NO, swap_offset(entry) * PAGE_NSECT, page2kva(page), PAGE_NSECT);
 }
 
+swap_entry_t
+swapfs_alloc_entry(void) {
+    if (swapfs_nr_free == 0) {
+        panic("no free space on swap fs!\n");
+    }
+
+    for (int offset = 1; offset < max_swap_offset; ++offset) {
+        if (!test_bit(offset, swapfs_bitmap)) {
+            set_bit(offset, swapfs_bitmap);
+            --swapfs_nr_free;
+            swap_entry_t entry = offset << 8;
+            return entry;
+        }
+    }
+
+    return 0;
+}
+
+void 
+swapfs_free_entry(swap_entry_t entry) {
+    size_t offset = swap_offset(entry);
+    clear_bit(offset, swapfs_bitmap);
+    ++swapfs_nr_free;
+}

--- a/labcodes_answer/lab7_result/kern/fs/swapfs.h
+++ b/labcodes_answer/lab7_result/kern/fs/swapfs.h
@@ -7,6 +7,7 @@
 void swapfs_init(void);
 int swapfs_read(swap_entry_t entry, struct Page *page);
 int swapfs_write(swap_entry_t entry, struct Page *page);
+swap_entry_t swapfs_alloc_entry(void);
+void swapfs_free_entry(swap_entry_t entry);
 
 #endif /* !__KERN_FS_SWAPFS_H__ */
-

--- a/labcodes_answer/lab7_result/kern/mm/pmm.c
+++ b/labcodes_answer/lab7_result/kern/mm/pmm.c
@@ -11,6 +11,7 @@
 #include <swap.h>
 #include <vmm.h>
 #include <kmalloc.h>
+#include <proc.h>
 
 /* *
  * Task State Segment:
@@ -587,6 +588,7 @@ tlb_invalidate(pde_t *pgdir, uintptr_t la) {
 struct Page *
 pgdir_alloc_page(pde_t *pgdir, uintptr_t la, uint32_t perm) {
     struct Page *page = alloc_page();
+    extern struct proc_struct *current;
     if (page != NULL) {
         if (page_insert(pgdir, page, la, perm) != 0) {
             free_page(page);
@@ -599,10 +601,10 @@ pgdir_alloc_page(pde_t *pgdir, uintptr_t la, uint32_t perm) {
                 assert(page_ref(page) == 1);
                 //cprintf("get No. %d  page: pra_vaddr %x, pra_link.prev %x, pra_link_next %x in pgdir_alloc_page\n", (page-pages), page->pra_vaddr,page->pra_page_link.prev, page->pra_page_link.next);
             } 
-            else  {  //now current is existed, should fix it in the future
-                //swap_map_swappable(current->mm, la, page, 0);
-                //page->pra_vaddr=la;
-                //assert(page_ref(page) == 1);
+            else if (current->mm) {  //now current is existed, should fix it in the future
+                swap_map_swappable(current->mm, la, page, 0);
+                page->pra_vaddr=la;
+                assert(page_ref(page) == 1);
                 //panic("pgdir_alloc_page: no pages. now current is existed, should fix it in the future\n");
             }
         }

--- a/labcodes_answer/lab7_result/kern/mm/swap.c
+++ b/labcodes_answer/lab7_result/kern/mm/swap.c
@@ -265,8 +265,11 @@ check_swap(void)
      } 
 
      //free_page(pte2page(*temp_ptep));
-     
+    free_page(pde2page(pgdir[0]));
+     pgdir[0] = 0;
+     mm->pgdir = NULL;
      mm_destroy(mm);
+     check_mm_struct = NULL;
          
      nr_free = nr_free_store;
      free_list = free_list_store;

--- a/labcodes_answer/lab8_result/kern/fs/swap/swapfs.c
+++ b/labcodes_answer/lab8_result/kern/fs/swap/swapfs.c
@@ -18,8 +18,8 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
-    swapfs_bitmap = kmalloc(max_swap_offset / 8);
-    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_bitmap = kmalloc((max_swap_offset + 7) / 8);
+    memset(swapfs_bitmap, 0, (max_swap_offset + 7) / 8);
     swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 

--- a/labcodes_answer/lab8_result/kern/fs/swap/swapfs.c
+++ b/labcodes_answer/lab8_result/kern/fs/swap/swapfs.c
@@ -5,6 +5,11 @@
 #include <ide.h>
 #include <pmm.h>
 #include <assert.h>
+#include <string.h>
+#include <kmalloc.h>
+
+static uint32_t *swapfs_bitmap;
+static size_t swapfs_nr_free;
 
 void
 swapfs_init(void) {
@@ -13,6 +18,9 @@ swapfs_init(void) {
         panic("swap fs isn't available.\n");
     }
     max_swap_offset = ide_device_size(SWAP_DEV_NO) / (PGSIZE / SECTSIZE);
+    swapfs_bitmap = kmalloc(max_swap_offset / 8);
+    memset(swapfs_bitmap, 0, max_swap_offset / 8);
+    swapfs_nr_free = max_swap_offset - 1; // entry 0 is not available
 }
 
 int
@@ -25,3 +33,27 @@ swapfs_write(swap_entry_t entry, struct Page *page) {
     return ide_write_secs(SWAP_DEV_NO, swap_offset(entry) * PAGE_NSECT, page2kva(page), PAGE_NSECT);
 }
 
+swap_entry_t
+swapfs_alloc_entry(void) {
+    if (swapfs_nr_free == 0) {
+        panic("no free space on swap fs!\n");
+    }
+
+    for (int offset = 1; offset < max_swap_offset; ++offset) {
+        if (!test_bit(offset, swapfs_bitmap)) {
+            set_bit(offset, swapfs_bitmap);
+            --swapfs_nr_free;
+            swap_entry_t entry = offset << 8;
+            return entry;
+        }
+    }
+
+    return 0;
+}
+
+void 
+swapfs_free_entry(swap_entry_t entry) {
+    size_t offset = swap_offset(entry);
+    clear_bit(offset, swapfs_bitmap);
+    ++swapfs_nr_free;
+}

--- a/labcodes_answer/lab8_result/kern/fs/swap/swapfs.h
+++ b/labcodes_answer/lab8_result/kern/fs/swap/swapfs.h
@@ -1,5 +1,5 @@
-#ifndef __KERN_FS_SWAP_SWAPFS_H__
-#define __KERN_FS_SWAP_SWAPFS_H__
+#ifndef __KERN_FS_SWAPFS_H__
+#define __KERN_FS_SWAPFS_H__
 
 #include <memlayout.h>
 #include <swap.h>
@@ -7,6 +7,7 @@
 void swapfs_init(void);
 int swapfs_read(swap_entry_t entry, struct Page *page);
 int swapfs_write(swap_entry_t entry, struct Page *page);
+swap_entry_t swapfs_alloc_entry(void);
+void swapfs_free_entry(swap_entry_t entry);
 
-#endif /* !__KERN_FS_SWAP_SWAPFS_H__ */
-
+#endif /* !__KERN_FS_SWAPFS_H__ */

--- a/labcodes_answer/lab8_result/kern/mm/pmm.c
+++ b/labcodes_answer/lab8_result/kern/mm/pmm.c
@@ -11,6 +11,7 @@
 #include <swap.h>
 #include <vmm.h>
 #include <kmalloc.h>
+#include <proc.h>
 
 /* *
  * Task State Segment:
@@ -599,10 +600,10 @@ pgdir_alloc_page(pde_t *pgdir, uintptr_t la, uint32_t perm) {
                 assert(page_ref(page) == 1);
                 //cprintf("get No. %d  page: pra_vaddr %x, pra_link.prev %x, pra_link_next %x in pgdir_alloc_page\n", (page-pages), page->pra_vaddr,page->pra_page_link.prev, page->pra_page_link.next);
             } 
-            else  {  //now current is existed, should fix it in the future
-                //swap_map_swappable(current->mm, la, page, 0);
-                //page->pra_vaddr=la;
-                //assert(page_ref(page) == 1);
+            else if (current->mm) {  //now current is existed, should fix it in the future
+                swap_map_swappable(current->mm, la, page, 0);
+                page->pra_vaddr=la;
+                assert(page_ref(page) == 1);
                 //panic("pgdir_alloc_page: no pages. now current is existed, should fix it in the future\n");
             }
         }

--- a/labcodes_answer/lab8_result/kern/mm/swap.c
+++ b/labcodes_answer/lab8_result/kern/mm/swap.c
@@ -265,8 +265,11 @@ check_swap(void)
      } 
 
      //free_page(pte2page(*temp_ptep));
-     
+    free_page(pde2page(pgdir[0]));
+     pgdir[0] = 0;
+     mm->pgdir = NULL;
      mm_destroy(mm);
+     check_mm_struct = NULL;
          
      nr_free = nr_free_store;
      free_list = free_list_store;


### PR DESCRIPTION
In the previous implementation of `swapfs`, error may occur if multiple processes need to swap the page of the same virtual address. This may cause conflict and one process's swapped page will be overwritten by other processes. This could be solved by using a simple bitmap allocator to allocate swap space.

In addition, the code does not render a page swappable in function `pgdir_alloc_page` but the comments say it should.