### PR TITLE
Correct the function name of "dup_fs" to "dup_files" to match its declaration.

### DIFF
--- a/labcodes/lab8/kern/fs/fs.c
+++ b/labcodes/lab8/kern/fs/fs.c
@@ -79,7 +79,7 @@ files_closeall(struct files_struct *filesp) {
 
 int
 dup_files(struct files_struct *to, struct files_struct *from) {
-//    cprintf("[dup_fs]\n");
+//    cprintf("[dup_files]\n");
     assert(to != NULL && from != NULL);
     assert(files_count(to) == 0 && files_count(from) > 0);
     if ((to->pwd = from->pwd) != NULL) {

--- a/labcodes_answer/lab8_result/kern/fs/fs.c
+++ b/labcodes_answer/lab8_result/kern/fs/fs.c
@@ -78,8 +78,8 @@ files_closeall(struct files_struct *filesp) {
 }
 
 int
-dup_fs(struct files_struct *to, struct files_struct *from) {
-//    cprintf("[dup_fs]\n");
+dup_files(struct files_struct *to, struct files_struct *from) {
+//    cprintf("[dup_files]\n");
     assert(to != NULL && from != NULL);
     assert(files_count(to) == 0 && files_count(from) > 0);
     if ((to->pwd = from->pwd) != NULL) {

--- a/labcodes_answer/lab8_result/kern/process/proc.c
+++ b/labcodes_answer/lab8_result/kern/process/proc.c
@@ -398,7 +398,7 @@ copy_fs(uint32_t clone_flags, struct proc_struct *proc) {
         goto bad_files_struct;
     }
 
-    if ((ret = dup_fs(filesp, old_filesp)) != 0) {
+    if ((ret = dup_files(filesp, old_filesp)) != 0) {
         goto bad_dup_cleanup_fs;
     }
 


### PR DESCRIPTION
在 labcodes_answer/lab8_result/kern/fs/fs.h 中 声明函数是dup_files，
在 fc.c 中的实现名却是dup_fs，在 proc.c 中也是按dup_fs调用的。
这里统一改为dup_files。
![image](https://user-images.githubusercontent.com/33002863/67365725-b3b5f980-f5a4-11e9-9cd3-eb33b5916199.png)
