### PR TITLE
bug fix: size should be sizeof(struct sfs_entry) in write_block when add_entry.

### DIFF
--- a/labcodes_answer/lab8_result/tools/mksfs.c
+++ b/labcodes_answer/lab8_result/tools/mksfs.c
@@ -450,7 +450,7 @@ add_entry(struct sfs_fs *sfs, struct cache_inode *current, struct cache_inode *f
     assert(current->inode.type == SFS_TYPE_DIR && strlen(name) <= SFS_MAX_FNAME_LEN);
     entry->ino = file->ino, strcpy(entry->name, name);
     uint32_t entry_ino = sfs_alloc_ino(sfs);
-    write_block(sfs, entry, sizeof(entry->name), entry_ino);
+    write_block(sfs, entry, sizeof(struct sfs_entry), entry_ino);
     append_block(sfs, current, sizeof(entry->name), entry_ino, name);
     file->inode.nlinks ++;
 }


### PR DESCRIPTION
原代码只向 block 写入了`entry` 中的 `ino` ，和 `name` 的一部分，且未包含最后的 '\0' 。由于 sizeof(entry->name) = 256（包括最后的 '\0'）， 而 sizeof(entry->ino) = 4 , 所以 name 的最后 3 个字符将丢失，只写入了不含 '\0' 的部分共 252 个字符。而且由于没有写入'\0'，还可能由于垃圾数据带来兼容性风险。

如果想复现问题也很方便：只需把 mksfs 中的 SFS_MAX_FNAME_LEN 改为较小值，比如改为 15. 正常编译并启动系统，shell 键入 ls, 会发现总长度本为 15 个字符的文件 faultreadkernel 被截断成 faultreadker, 共 15 - 3 = 12 个字符。