### PR TITLE
fix wrong answer of lab5

### DIFF
--- a/labcodes_answer/lab5_result/kern/mm/kmalloc.c
+++ b/labcodes_answer/lab5_result/kern/mm/kmalloc.c
@@ -187,7 +187,7 @@ static void slob_free(void *block, int size)
 
 
 void check_slab(void) {
-  cprintf("check_slab() success\n");
+  cprintf("check_slab() success!\n");
 }
 
 void


### PR DESCRIPTION
The missing '!' resulted in the problem that make grade was not able to get full mark in lab5